### PR TITLE
Added bash_completion file (now with improved formatting!)

### DIFF
--- a/etc/bash_completion.d/minecraft_server
+++ b/etc/bash_completion.d/minecraft_server
@@ -1,26 +1,25 @@
-_minecraft_server()
-{
-    local cur prev opts base
+_minecraft_server() {
+    local CUR PREV OPTS
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    CUR="${COMP_WORDS[COMP_CWORD]}"
+    PREV="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="start stop force-stop restart force-restart create new delete remove
+    OPTS="start stop force-stop restart force-restart create new delete remove
     disable enable status show sync send screen watch logrotate backup
     map overviewer update"
 
-    case "${prev}" in
+    case "$PREV" in
         start|stop|force-stop|restart|force-restart|delete|remove|disable|\
         sync|send|screen|watch|logrotate|backup|map|overviewer)
-            local worlds="world"
-            COMPREPLY=( $(compgen -W "${worlds}" -- ${cur}) )
+            local WORLDS="world"
+            COMPREPLY=( $(compgen -W "$WORLDS" -- $CUR) )
             return 0
             ;;
         *)
         ;;
     esac
 
-    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    COMPREPLY=($(compgen -W "$OPTS" -- $CUR))
     return 0
 }
 complete -F _minecraft_server minecraft_server


### PR DESCRIPTION
I looked into it a bit, and the bash arrays are actually required since the bash_completion program is just sourcing this file. The variables COMP_WORDS, etc. are declared elsewhere, so they are always going to be bash arrays.

I changed the things I could, and I'm making a new pull request now. I'll get around to making it fill in world names and stuff soon.
