### PR TITLE
fixed map URL being unclickable in-game

### DIFF
--- a/minecraft_server
+++ b/minecraft_server
@@ -2034,8 +2034,7 @@ case "$1" in
         worldBackup $WORLD
         overviewer $WORLD
         sendCommand $WORLD "save-on"
-        sendCommand $WORLD "say Mapping is complete.  You can access the maps at:"
-        sendCommand $WORLD "say $MAPS_URL/$WORLD"
+        sendCommand $WORLD "/tellraw @a {\"text\":\"\",\"extra\":[{\"text\":\"[Server] Mapping is complete.  You can access the maps \"},{\"text\":\"here\",\"color\":\"aqua\",\"clickEvent\":{\"action\":\"open_url\",\"value\":\"$MAPS_URL/$WORLD\"}},{\"text\":\".\"}]}"
       else
         worldBackup $WORLD
         overviewer $WORLD


### PR DESCRIPTION
The new method is ugly in code, but it makes the map URL clickable in-game.

On a side note, we need to implement a method of specifying the server's URL somewhere other than in the actual program.  Every time there's an update I have to change it manually.
