### PR TITLE
Dockerify MSCS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,4 @@ USER minecraft
 
 EXPOSE 25565
 
-ENTRYPOINT ["mscs","-f"]
-CMD ["start"]
+CMD mscs start $WORLD && sleep 3 && mscs watch $WORLD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM java:8
 #This dockerfile setup the basic things need for mscs to run inside a docker container.
 
 
@@ -6,7 +6,7 @@ FROM debian:jessie
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys AB6EAF871F4C1BCE \
 	&& echo "deb http://overviewer.org/debian ./" >> /etc/apt/sources.list.d/overviewer.list \
     && apt-get update \
-	&& apt-get update && apt-get install -y default-jre perl python make wget rdiff-backup socat iptables minecraft-overviewer \
+	&& apt-get update && apt-get install -y perl python make wget rdiff-backup socat iptables minecraft-overviewer \
 	&& rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,22 +9,26 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys AB6EAF871F4C1BCE \
 	&& apt-get update && apt-get install -y default-jre perl python make wget rdiff-backup socat iptables minecraft-overviewer \
 	&& rm -rf /var/lib/apt/lists/*
 
+# grab gosu for easy step-down from root
+ENV gosu_version=1.7
+
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && apt-get update && apt-get install -y curl rsync tmux && rm -rf /var/lib/apt/lists/* \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
+
 #Install Mscs
 RUN mkdir -p /usr/src/mscs /opt/mscs/worlds /opt/mscs/maps /opt/mscs/backups
 ADD . /usr/src/mscs
 WORKDIR /usr/src/mscs
 RUN make install
-RUN chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
-USER minecraft
 
-#This container will assume there are a valid mscs world setup ready for it. This can be 
-#done by -v <volume>:/opt/mscs at runtime.
+WORKDIR /opt/mscs
 
-
-#If you would like to also make a world inside of the container check the docker file in
-# myWorld in this directory.
-
-
+VOLUME ['/opt/mscs/worlds', '/opt/mscs/maps', '/opt/mscs/backups']
 
 EXPOSE 25565
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:jessie
+#This dockerfile setup the basic things need for mscs to run inside a docker container.
+
+
+#Install pre requirements
+RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys AB6EAF871F4C1BCE \
+	&& echo "deb http://overviewer.org/debian ./" >> /etc/apt/sources.list.d/overviewer.list \
+    && apt-get update \
+	&& apt-get update && apt-get install -y default-jre perl python make wget rdiff-backup socat iptables minecraft-overviewer \
+	&& rm -rf /var/lib/apt/lists/*
+
+#Install Mscs
+RUN mkdir -p /usr/src/mscs /opt/mscs/worlds /opt/mscs/maps /opt/mscs/backups
+ADD . /usr/src/mscs
+WORKDIR /usr/src/mscs
+RUN make install
+RUN chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
+USER minecraft
+
+#This container will assume there are a valid mscs world setup ready for it. This can be 
+#done by -v <volume>:/opt/mscs at runtime.
+
+
+#If you would like to also make a world inside of the container check the docker file in
+# myWorld in this directory.
+
+
+
+EXPOSE 25565
+
+ENTRYPOINT ["mscs","-f"]
+CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN make install
 
 WORKDIR /opt/mscs
 
-VOLUME ['/opt/mscs/worlds', '/opt/mscs/maps', '/opt/mscs/backups']
+VOLUME /opt/mscs/worlds /opt/mscs/maps /opt/mscs/backups
 
 EXPOSE 25565
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,14 @@ MSCS_INIT_D := /etc/init.d/mscs
 MSCS_SERVICE := /etc/systemd/system/mscs.service
 MSCS_COMPLETION := /etc/bash_completion.d/mscs
 
-.PHONY: install update clean
+.PHONY: docker-build docker-run install update clean
+
+docker-build:
+	docker build -t egut/mscs .
+	docker build -t myworld myWorld
+
+docker-run: docker-build
+	docker run -t -p 25565:25565 --name=myworld -d myworld
 
 install: update
 	adduser --system --group --home $(MSCS_HOME) --quiet $(MSCS_USER)

--- a/mscs
+++ b/mscs
@@ -22,18 +22,44 @@ if [ -r $MSCS_DEFAULTS ]; then
   MSCS_ARGS="-c $MSCS_DEFAULTS "
 fi
 
+# gosu for easy step-down from root
+# see: https://github.com/tianon/gosu
+GOSU=${GOSU:-"/usr/local/bin/gosu"}
+
 # Setup the default user name.
 USER_NAME=${USER_NAME:-minecraft}
 
 # Setup the default installation location.
 LOCATION=${LOCATION:-"/opt/mscs"}
 
+#Check permissions LOCATION and some top directories
+if [ -n "$(find $(find $LOCATION -maxdepth 2) \! -user "$USER_NAME" -print -prune -o -prune)" ]; then
+  echo "Note: Wrong owner of the directory, fixing"
+  if [ "$(whoami)" = "root" ]; then
+    chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
+  else
+    sudo chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
+  fi
+fi
+
 # Setup the arguments to the msctl script.
 MSCS_ARGS="-p $PROG -l $LOCATION $MSCS_ARGS $@"
 
 # Run the msctl script.
 if [ "$USER_NAME" = "$(whoami)" ]; then
+  # Correct user
   msctl $MSCS_ARGS
+
+elif [ "$(whoami)" = "root" ]; then
+  # Running as root, step-down to user
+  if [ -x $GOSU ]; then
+    $GOSU $USER_NAME msctl $MSCS_ARGS
+
+  else
+    su $USER_NAME -p -c "msctl $MSCS_ARGS"
+  fi
+
 else
+  # Running as other user, switch
   sudo -u $USER_NAME msctl $MSCS_ARGS
 fi

--- a/mscs
+++ b/mscs
@@ -36,9 +36,9 @@ LOCATION=${LOCATION:-"/opt/mscs"}
 if [ -n "$(find $(find $LOCATION -maxdepth 2) \! -user "$USER_NAME" -print -prune -o -prune)" ]; then
   echo "Note: Wrong owner of the directory, fixing"
   if [ "$(whoami)" = "root" ]; then
-    chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
+    chmod -R u+w $LOCATION && chown -R minecraft:minecraft $LOCATION
   else
-    sudo chmod -R u+w /opt/mscs && chown -R minecraft:minecraft /opt/mscs
+    sudo chmod -R u+w $LOCATION && sudo chown -R minecraft:minecraft $LOCATION
   fi
 fi
 

--- a/msctl
+++ b/msctl
@@ -140,8 +140,15 @@ Options:
   -l <location>
     Uses <location> as the base path for data.  Overrides configuration file
     options.
+
+  -f
+    Run the server in foreground. More or less only needed when running
+    inside a docker container.
 EOF
 }
+
+# Default run the minecraft server in the background.
+RUN_IN_FOREGROUND=0
 
 # Parse command-line options
 # ---------------------------------------------------------------------------
@@ -173,6 +180,10 @@ while [ "$1" != "${1#-}" ]; do
         echo "$PROG: '-l' needs a location path argument."
         exit 1
       fi
+    ;;
+    -f)
+      echo "Will run minecraft server in foreground."
+      RUN_IN_FOREGROUND=1
     ;;
     *)
       echo "$PROG: unknown option '$1'."
@@ -1209,9 +1220,15 @@ start() {
     exit 1
   fi
   # Start the server.
-  sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
-    $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
-    }" &
+  if [ $RUN_IN_FOREGROUND -eq 1 ]; then
+    sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
+      $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
+      }"
+  else
+    sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
+      $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
+      }" &
+  fi
   # Verify the server is running.
   if [ $? -ne 0 ]; then
     printf "Error starting the server.\n"

--- a/msctl
+++ b/msctl
@@ -140,15 +140,9 @@ Options:
   -l <location>
     Uses <location> as the base path for data.  Overrides configuration file
     options.
-
-  -f
-    Run the server in foreground. More or less only needed when running
-    inside a docker container.
 EOF
 }
 
-# Default run the minecraft server in the background.
-RUN_IN_FOREGROUND=0
 
 # Parse command-line options
 # ---------------------------------------------------------------------------
@@ -180,10 +174,6 @@ while [ "$1" != "${1#-}" ]; do
         echo "$PROG: '-l' needs a location path argument."
         exit 1
       fi
-    ;;
-    -f)
-      echo "Will run minecraft server in foreground."
-      RUN_IN_FOREGROUND=1
     ;;
     *)
       echo "$PROG: unknown option '$1'."
@@ -1220,15 +1210,10 @@ start() {
     exit 1
   fi
   # Start the server.
-  if [ $RUN_IN_FOREGROUND -eq 1 ]; then
-    sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
-      $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
-      }"
-  else
-    sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
-      $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
-      }" &
-  fi
+  sh -c "tail -f --pid=\$$ '$WORLD_DIR/console.in' | {
+    $SERVER_COMMAND mscs-world='$1' > '$WORLD_DIR/console.out' 2>&1; kill \$$;
+    }" &
+
   # Verify the server is running.
   if [ $? -ne 0 ]; then
     printf "Error starting the server.\n"

--- a/myWorld/Dockerfile
+++ b/myWorld/Dockerfile
@@ -1,0 +1,15 @@
+FROM egut/mscs
+#This is an example container that setup a example world. 
+
+#Variables that you should override in docker container that depend on this container.
+ENV WORLD=myWorld
+
+#To enable the world you need to change the following line to ENV EULA=ture
+#This also implicate that you accept Mojang's EULA.
+ENV EULA=false
+
+# This will create a world for you and use the parent start command to also start it. 
+RUN mscs create $WORLD 25565
+RUN echo "eula=$EULA" > /opt/mscs/worlds/$WORLD/eula.txt
+
+#Here you can add more environment options and adding files to your world.


### PR DESCRIPTION
As I'm a fan of docker and think mscs is really good so I placed mscs and all its dependencies in a docker container. 

This also need some small tweaks to mscs to enable it run in foreground and not background as you would normally do. So now there are a one extra option -f  that starts the minecraft server in the foreground (default background).

I also added 2 dockerfiles show casing how to set it up.

