### PR TITLE
Systemd service

### DIFF
--- a/mscs.service
+++ b/mscs.service
@@ -7,6 +7,7 @@ After=network.target
 [Service]
 User=minecraft
 Group=minecraft
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
 ExecStart=/usr/local/bin/mscs start
 ExecStop=/usr/local/bin/mscs stop
 ExecReload=/usr/local/bin/mscs restart

--- a/mscs.service
+++ b/mscs.service
@@ -5,6 +5,8 @@ Requires=network.target
 After=network.target
 
 [Service]
+User=minecraft
+Group=minecraft
 ExecStart=/usr/local/bin/mscs start
 ExecStop=/usr/local/bin/mscs stop
 ExecReload=/usr/local/bin/mscs restart


### PR DESCRIPTION
This pull request is twofold.

First, make sure that the service is run as the correct user and group rather than as (I presume) root.

Second, make sure `/usr/local/bin` is in the service's PATH variable. I don't know if this is an issue on Debian, but openSUSE does not have `/usr/local/bin` in its PATH for systemd services. This is a fairly easy fix for that.