### PR TITLE
fixing bugs related to shell glob expansion and softlink behavior

### DIFF
--- a/msctl
+++ b/msctl
@@ -980,7 +980,7 @@ watchLog() {
 # ---------------------------------------------------------------------------
 syncMirrorImage() {
   # Sync the world server.
-  cp -Ru "$WORLDS_LOCATION/$1/$1/*" "$WORLDS_LOCATION/$1/$1-original"
+  cp -Ru "$WORLDS_LOCATION/$1/$1/"* "$WORLDS_LOCATION/$1/$1-original"
   if [ $? -ne 0 ]; then
     printf "Error synchronizing mirror images for world $1.\n"
     exit 1
@@ -1042,11 +1042,11 @@ start() {
       mv "$WORLDS_LOCATION/$1/$1-original" "$WORLDS_LOCATION/$1/$1"
     fi
     # Copy the world files over to the mirror.
-    cp -R "$WORLDS_LOCATION/$1/$1/*" "$MIRROR_PATH/$1"
+    cp -R "$WORLDS_LOCATION/$1/$1/"* "$MIRROR_PATH/$1"
     # Rename the original world file directory.
     mv "$WORLDS_LOCATION/$1/$1" "$WORLDS_LOCATION/$1/$1-original"
     # Create a symlink from the world file directory's original name to the mirrored files.
-    ln -s "$MIRROR_PATH/$1" "$WORLDS_LOCATION/$1/$1"
+    ln -s "$MIRROR_PATH/$1/" "$WORLDS_LOCATION/$1/$1"
   fi
   # Change to the world's directory.
   cd $WORLD_DIR


### PR DESCRIPTION
Hello, 

This is to address two issues I came across when I enabled mirroring for a server using the msctl script. 

**Issue 1:** globbing (`*`) being done within double quotes
  - shell globbing expansion does not (normally?) occur within double quotes. For example the command 
`cp -Ru "src/path/*" "dest/path"` result in the error: `cp: cannot stat '/src/path/*': No such file or directory`
  - This shell globbing pattern was being done in two places: `syncMirrorImage()` and `start()`, and the error above was observed in the output of the `mscs start` and `mscs stop` commands. 
  - I just moved the `*` outside of the double quotes so that it is properly handled

**Issue 2:** symlink causing existing mirrored world not to be read properly
  - i think this may be more of an issue with how the minecraft server handles symlinks, but when enabling mirroring on an existing world, I was noticing that my world was being reset as if it never existed, whenever the server started. On closer inspection of the mirror directory (`/dev/shm/mscs/world`), a fresh new `world` directory was being placed inside of it (so I would get `/dev/shm/mscs/world/world`) as if the contents of `/dev/shm/mscs/world` were being ignored.
  - I suspect that the symlink created with `ln -s "$MIRROR_PATH/$1/" "$WORLDS_LOCATION/$1/$1"` in the `start` function is not being dereferenced properly by the server
  - Adding a trailing slash to the softlink target seems to have fixed it for me