### PR TITLE
fixing bug WORLDS_LOCATION var in start function

### DIFF
--- a/msctl
+++ b/msctl
@@ -1035,7 +1035,7 @@ start() {
     fi
     # Check for a clean dismount from the previous server run.  If we have a
     # <world>-original directory within <world> we didn't stop cleanly.
-    if [ -d "WORLDS_LOCATION/$1/$1-original" ]; then
+    if [ -d "$WORLDS_LOCATION/$1/$1-original" ]; then
       # Remove the symlink to the world-file mirror image.
       rm -r "$WORLDS_LOCATION/$1/$1"
       # Move the world files back to their original path name.


### PR DESCRIPTION
in `start()` a directory check starting with `WORLDS_LOCATION` was not properly referenced. added `$WORLDS_LOCATION` to fix