### PR TITLE
Feature Request - prevent backups from copying symlink files

### DIFF
--- a/msctl
+++ b/msctl
@@ -1098,7 +1098,7 @@ stop() {
   sendCommand $1 "end"
   # Synchronize the mirror image of the world prior to closing, if
   # required.
-  if [ $ENABLE_MIRROR -eq 1 ] && [ -d $MIRROR_PATH ]; then
+  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1" ] && [ -d $WORLDS_LOCATION/$1/$1-original ]; then
     syncMirrorImage $1
     # Remove the symlink to the world-file mirror image.
     rm -r "$WORLDS_LOCATION/$1/$1"
@@ -1137,7 +1137,7 @@ worldBackup() {
   fi
   # Synchronize the mirror image of the world prior to closing, if
   # required.
-  if [ $ENABLE_MIRROR -eq 1 ] && [ -d $MIRROR_PATH ]; then
+  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1" ] && [ -d $WORLDS_LOCATION/$1/$1-original ]; then
     syncMirrorImage $1
   fi
   # Determine if we need to exclude the mirrored symlink or not

--- a/msctl
+++ b/msctl
@@ -1037,7 +1037,11 @@ start() {
     # <world>-original directory within <world> we didn't stop cleanly.
     if [ -d "WORLDS_LOCATION/$1/$1-original" ]; then
       # Remove the symlink to the world-file mirror image.
-      rm -r "$WORLDS_LOCATION/$1/$1"
+      # if recently restored from backup, this symlink may or may not exist
+      if [ -L "$WORLDS_LOCATION/$1/$1" ]; then
+        rm -r "$WORLDS_LOCATION/$1/$1"
+      fi
+
       # Move the world files back to their original path name.
       mv "$WORLDS_LOCATION/$1/$1-original" "$WORLDS_LOCATION/$1/$1"
     fi
@@ -1130,8 +1134,13 @@ worldBackup() {
     echo "Error creating backup dir $BACKUP_LOCATION"
     return 1
   fi
+  # Synchronize the mirror image of the world prior to closing, if
+  # required.
+  if [ $ENABLE_MIRROR -eq 1 ] && [ -d $MIRROR_PATH ]; then
+    syncMirrorImage $1
+  fi
   # Create the backup.
-  if ! $RDIFF_BACKUP -v5 --print-statistics "$WORLDS_LOCATION/$1" "$BACKUP_LOCATION/$1" >> "$BACKUP_LOG"; then
+  if ! $RDIFF_BACKUP -v5 --print-statistics --exclude-symbolic-links "$WORLDS_LOCATION/$1" "$BACKUP_LOCATION/$1" >> "$BACKUP_LOG"; then
     echo "Error doing backup of world $1"
     return 1
   fi

--- a/msctl
+++ b/msctl
@@ -1129,6 +1129,7 @@ forceStop() {
 # @return A 0 if backup successful, a 1 otherwise
 # ---------------------------------------------------------------------------
 worldBackup() {
+  local EXCLUDE_OPTION
   # Make sure that the backup location exists.
   if ! mkdir -p "$BACKUP_LOCATION"; then
     echo "Error creating backup dir $BACKUP_LOCATION"
@@ -1139,8 +1140,12 @@ worldBackup() {
   if [ $ENABLE_MIRROR -eq 1 ] && [ -d $MIRROR_PATH ]; then
     syncMirrorImage $1
   fi
+  # Determine if we need to exclude the mirrored symlink or not
+  if [ -L "$WORLDS_LOCATION/$1/$1" ]; then
+    EXCLUDE_OPTION="--exclude $WORLDS_LOCATION/$1/$1"
+  fi
   # Create the backup.
-  if ! $RDIFF_BACKUP -v5 --print-statistics --exclude-symbolic-links "$WORLDS_LOCATION/$1" "$BACKUP_LOCATION/$1" >> "$BACKUP_LOG"; then
+  if ! $RDIFF_BACKUP -v5 --print-statistics $EXCLUDE_OPTION "$WORLDS_LOCATION/$1" "$BACKUP_LOCATION/$1" >> "$BACKUP_LOG"; then
     echo "Error doing backup of world $1"
     return 1
   fi
@@ -1153,6 +1158,7 @@ worldBackup() {
   fi
   return 0
 }
+
 
 # ---------------------------------------------------------------------------
 # List the backups for the world server.

--- a/msctl
+++ b/msctl
@@ -1159,7 +1159,6 @@ worldBackup() {
   return 0
 }
 
-
 # ---------------------------------------------------------------------------
 # List the backups for the world server.
 #


### PR DESCRIPTION
When backing up a mirrored world, the current behavior is to simply backup everything in the world directory, including the symlinks to the mirrored directory. This has a few implications:

- the backup operation is likely not catching the most recent world changes (if any), since `worldBackup` is not actually doing a sync call before it does it's thing
- since the mirror directory is defined in the root `mscs.defaults` file (hence not part of the backed up files themselves), it could potentially be changed by the user causing an unintended side effect of their world not behaving properly from a restore backup operation
- a symlink can also cause some issues when restoring a backup to another machine as is not resolved properly

This request sidesteps these issues altogether by simply ignoring the symlink in the backup via these three changes:

1. the behavior of the backup operation to use `rdiff-backup`'s flag of `--exclude-symbolic-links`
2. `start` function now needs to account for the fact that the symlink world file (`$WORLDLOCATION/$1/$1`) may not be present. On a backup-restore operation only the (non-symlink) `$WORLDLOCATION/$1/$1-original` directory would be available
3. the `worldBackup` function needs to perform a sync operation immediately prior to calling `rdiff-backup`
