### PR TITLE
allow useradd to create home directory from install target, not the $(MSCS_HOME) target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ UPDATE_D := $(wildcard update.d/*)
 
 .PHONY: install update clean
 
-install: $(MSCS_HOME) update
+install: update
 	useradd --system --user-group --create-home --home $(MSCS_HOME) $(MSCS_USER)
 	chown -R $(MSCS_USER):$(MSCS_GROUP) $(MSCS_HOME)
 	if which systemctl; then \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UPDATE_D := $(wildcard update.d/*)
 .PHONY: install update clean
 
 install: update
-	useradd --system --user-group --create-home --home $(MSCS_HOME) $(MSCS_USER)
+	useradd --system --user-group --create-home -K UMASK=0022 --home $(MSCS_HOME) $(MSCS_USER)
 	chown -R $(MSCS_USER):$(MSCS_GROUP) $(MSCS_HOME)
 	if which systemctl; then \
 		systemctl -f enable mscs.service; \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,3 @@ clean:
 		rm -f $(MSCS_INIT_D); \
 	fi
 	rm -f $(MSCTL) $(MSCS) $(MSCS_COMPLETION)
-
-$(MSCS_HOME):
-	mkdir -p -m 755 $(MSCS_HOME)


### PR DESCRIPTION
It is useful to be able to work as the `minecraft` user that is created from the `install` target in the Makefile. 

However, because the `install` target runs the `$(MSCS_HOME)` target beforehand (thus creating the home directory beforehand) the `useradd` command fails to pull over useful shell default files (like `.bashrc`, `.profile`, etc...) and anything else that may be living in `/etc/skel`. I don't know if this was  intended behavior or not since the `--create-home` option is supposed to setup those files for a newly added user.

This PR contains two changes: 

- remove the call to the `$(MSCS_HOME)` target when running `make install`. The `MSCS_HOME` directory will still be created by the `useradd` command, and on most systems, i think this would be enough by itself. The `useradd` command would then properly setup the home directory with the system default files

- add the `-K UMASK=0022` option to the `useradd` command. This just ensures that on a system with some differing defaults it still sets up the mscs home directory with the intended permissions the same way.



