### PR TITLE
getJavaMemory(): changed ps flag --no-headers

### DIFF
--- a/msctl
+++ b/msctl
@@ -187,7 +187,7 @@ getJavaPID() {
 getJavaMemory() {
   local PID
   PID=$(getJavaPID "$1")
-  ps -h -p $PID -o rss
+  ps --no-headers -p $PID -o rss
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#158 
Remedies incompatibility of -h flag with procps (ps) version 3.2.8 on older Linux Mint 13 (3.2.0-23-generic based on Ubuntu 12.04). 

The --no-headers flag appears to be widely supported for turning off header display of ps output. 

Newer Debian, Ubuntu and Mint uses procps version 3.3.x which seems to be based on procps-ng rather than the older procps.