### PR TITLE
Fix missing quotation marks in json-query command

### DIFF
--- a/msctl
+++ b/msctl
@@ -1616,7 +1616,7 @@ queryDetailedStatusJSON() {
   if [ -n "$STATUS" ]; then
     NUMPLAYERS=$(printf "%s" "$STATUS" | cut -f 19)
     if [ $NUMPLAYERS -gt 0 ]; then
-      PLAYERS=$(printf "\"%s\"" "$STATUS" | cut -f 30)
+      PLAYERS=$(printf "%s\"" "$PLAYERS" $(printf "%s" "$STATUS" | cut -f $((30))))
       COUNTER=1
       while [ $COUNTER -lt $NUMPLAYERS ]; do
         PLAYERS=$(printf "%s, \"%s\"" "$PLAYERS" $(printf "%s" "$STATUS" | cut -f $((30+$COUNTER))))

--- a/msctl
+++ b/msctl
@@ -1671,7 +1671,7 @@ worldStatus() {
       VERSION=$(printf "%s" "$STATUS" | cut -f 13)
       printf "running version %s (%d of %d users online).\n" "$VERSION" $NUM $MAX
       if [ $NUM -gt 0 ]; then
-        PLAYERS=$(printf "%s" "$STATUS" | cut -f 30)
+        PLAYERS=$(printf "\"%s\"" $(printf "%s" "$STATUS" | cut -f 30))
         COUNTER=1
         while [ $COUNTER -lt $NUM ]; do
           PLAYERS=$(printf "%s, %s" "$PLAYERS" $(printf "%s" "$STATUS" | cut -f $((30+$COUNTER))))


### PR DESCRIPTION
Performing the `query-json` command would yield the first entry in the
json "players" array missing quotation marks; this fixes it

p.s. I couldn't figure out a way to fork the original project multiple times, so I just went and created a separate branch and then made the commit in there... if there's a better way to do this let me know b/c I'm still learning this stuff haha. Also sorry about committing directly to the master branch before