### PR TITLE
RFC: Rework version_manifest.json update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,9 +622,15 @@ will be started using the `minecraft` user instead for security purposes.
     Run the Minecraft Overviewer mapping software on the Minecraft world.
     Map all worlds by default.
 
-* update
+* update [world]
 
-    Update the client and server software packages.
+    Update the server software for the Minecraft world server.  Update
+    server software for all worlds by default.
+
+* force-update [world]
+
+    Refresh version information prior to running update for the world server,
+    regardless of how recently the version information was updated.
 
 * query [world]
 

--- a/mscs.completion
+++ b/mscs.completion
@@ -12,7 +12,7 @@ _mscs() {
   OPTS="
     backup console create delete disable enable force-restart force-stop list
     list-backups logrotate map new overviewer remove restart restore-backup
-    broadcast send show start status stop sync update watch usage
+    broadcast send show start status stop sync update force-update watch usage
   "
 
   LIST_OPTS="enabled disabled running stopped"
@@ -30,7 +30,7 @@ _mscs() {
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;
       disable|sync|send|watch|logrotate|backup|map|overviewer|\
-      list-backups|restore-backup)
+      list-backups|restore-backup|update|force-update)
         WORLDS=$(list_worlds enabled)
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;

--- a/msctl
+++ b/msctl
@@ -1869,7 +1869,7 @@ fi
 #   mscs-worlds-location=/opt/mscs/worlds
 #   mscs-versions-url=https://launchermeta.mojang.com/mc/game/version_manifest.json
 #   mscs-versions-json=/opt/mscs/version_manifest.json
-#   mscs-versions-duration=1440
+#   mscs-versions-duration=30
 #   mscs-lockfile-duration=1440
 #   mscs-default-world=world
 #   mscs-default-port=25565
@@ -1985,7 +1985,7 @@ WORLDS_LOCATION=$(getDefaultsValue 'mscs-worlds-location' $LOCATION'/worlds')
 # The location to store the version_manifest.json file.
 VERSIONS_JSON=$(getDefaultsValue 'mscs-versions-json' $LOCATION'/version_manifest.json')
 # The duration (in minutes) to keep the version_manifest.json file before updating.
-VERSIONS_DURATION=$(getDefaultsValue 'mscs-versions-duration' '1440')
+VERSIONS_DURATION=$(getDefaultsValue 'mscs-versions-duration' '30')
 # The duration (in minutes) to keep lock files before removing.
 LOCKFILE_DURATION=$(getDefaultsValue 'mscs-lockfile-duration' '1440')
 

--- a/msctl
+++ b/msctl
@@ -2034,14 +2034,12 @@ OVERVIEWER_URL=$(getDefaultsValue 'mscs-overviewer-url' 'http://overviewer.org')
 MAPS_LOCATION=$(getDefaultsValue 'mscs-maps-location' $LOCATION'/maps')
 MAPS_URL=$(getDefaultsValue 'mscs-maps-url' 'http://minecraft.server.com/maps')
 
-# Grab the latest version information.
-# ---------------------------------------------------------------------------
-updateVersionsJSON
-
 # Respond to the command line arguments.
 # ---------------------------------------------------------------------------
 case "$1" in
   start)
+    # Grab the latest version information.
+    updateVersionsJSON
     # Figure out which worlds to start.
     WORLDS=$(getEnabledWorlds)
     if [ -z "$WORLDS" ]; then
@@ -2110,6 +2108,8 @@ case "$1" in
     printf ".\n"
   ;;
   restart|reload|force-restart|force-reload)
+    # Grab the latest version information.
+    updateVersionsJSON
     # Figure out which worlds to restart.
     if isWorldEnabled "$2"; then
       WORLDS="$2"
@@ -2213,6 +2213,8 @@ case "$1" in
     printf ".\n"
   ;;
   enable)
+    # Grab the latest version information.
+    updateVersionsJSON
     # Get list of disabled worlds.
     if ! isWorldAvailable "$2"; then
       printf "World not found, unable to enable world '$2'.\n"
@@ -2492,6 +2494,8 @@ case "$1" in
     fi
   ;;
   update)
+    # Grab the latest version information.
+    updateVersionsJSON
     # Figure out which worlds to update.
     if isWorldEnabled "$2"; then
       WORLDS="$2"
@@ -2542,6 +2546,8 @@ case "$1" in
     printf ".\n"
   ;;
   map|overviewer)
+    # Grab the latest version information.
+    updateVersionsJSON
     # Make sure that the Minecraft Overviewer software exists.
     if [ ! -e "$OVERVIEWER_BIN" ]; then
       printf "Minecraft Overviewer software not found.\n"

--- a/msctl
+++ b/msctl
@@ -541,16 +541,20 @@ updateVersionsJSON() {
     cp -p "$VERSIONS_JSON" "$VERSIONS_JSON.bak"
     # Delete the version_manifest.json file if it is old.
     find "$VERSIONS_JSON" -mmin +"$VERSIONS_DURATION" -delete
+    if [ ! -s $VERSIONS_JSON ]; then
+      printf "The version manifest was out of date, it has been removed.\n"
+    fi
   fi
   # Download the version_manifest.json file if it does not exist.
   if [ ! -s $VERSIONS_JSON ]; then
+    printf "Downloading current Minecraft version manifest.\n"
     $WGET --no-use-server-timestamps -qO "$VERSIONS_JSON" "$MINECRAFT_VERSIONS_URL"
     if [ $? -ne 0 ]; then
       if [ -s $VERSIONS_JSON.bak ]; then
-        printf "Error downloading the Minecraft version_manifest.json file, using an old copy.\n"
+        printf "Error downloading the version manifest, using a backup.\n"
         cp -p "$VERSIONS_JSON.bak" "$VERSIONS_JSON"
       else
-        printf "Error downloading the Minecraft version_manifest.json file.\n"
+        printf "Error downloading the version manifest, exiting.\n"
         exit 1
       fi
     fi

--- a/msctl
+++ b/msctl
@@ -529,17 +529,9 @@ setServerPropertiesValue() {
 }
 
 # ---------------------------------------------------------------------------
-# Get the current Minecraft version number.
-#
-# @param 1 The world server.
-# @return The current Minecraft version number.
+# Update the version_manifest.json file.
 # ---------------------------------------------------------------------------
-getCurrentMinecraftVersion() {
-  local VERSION TYPE
-  # Make sure the server software directory exists.
-  mkdir -p "$DEFAULT_SERVER_LOCATION"
-  # Determine the version type for the current world.
-  TYPE=$(getMSCSValue "$1" "mscs-version-type" "$DEFAULT_VERSION_TYPE")
+updateVersionsJSON() {
   if [ -s $VERSIONS_JSON ]; then
     # Make a backup copy of the version_manifest.json file.
     cp -p "$VERSIONS_JSON" "$VERSIONS_JSON.bak"
@@ -559,6 +551,18 @@ getCurrentMinecraftVersion() {
       fi
     fi
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Get the current Minecraft version number.
+#
+# @param 1 The world server.
+# @return The current Minecraft version number.
+# ---------------------------------------------------------------------------
+getCurrentMinecraftVersion() {
+  local VERSION TYPE
+  # Determine the version type for the current world.
+  TYPE=$(getMSCSValue "$1" "mscs-version-type" "$DEFAULT_VERSION_TYPE")
   # Extract the current version information.
   VERSION=$($PERL -0777ne '
     use JSON;
@@ -2029,6 +2033,10 @@ OVERVIEWER_BIN=$(getDefaultsValue 'mscs-overviewer-bin' $(which overviewer.py))
 OVERVIEWER_URL=$(getDefaultsValue 'mscs-overviewer-url' 'http://overviewer.org')
 MAPS_LOCATION=$(getDefaultsValue 'mscs-maps-location' $LOCATION'/maps')
 MAPS_URL=$(getDefaultsValue 'mscs-maps-url' 'http://minecraft.server.com/maps')
+
+# Grab the latest version information.
+# ---------------------------------------------------------------------------
+updateVersionsJSON
 
 # Respond to the command line arguments.
 # ---------------------------------------------------------------------------

--- a/msctl
+++ b/msctl
@@ -142,6 +142,10 @@ Actions:
     Update the server software for the Minecraft world server.  Update
     server software for all worlds by default.
 
+  force-update <world>
+    Refresh version information prior to running update for the world server,
+    regardless of how recently the version information was updated.
+
   query <world>
     Run a detailed Query on the Minecraft world server.
 
@@ -2493,7 +2497,11 @@ case "$1" in
       exit 1
     fi
   ;;
-  update)
+  update|force-update)
+    # Handle the force option.
+    if [ "$(echo \"$1\" | cut -d '-' -f1)" = "force" ]; then
+      rm -f $VERSIONS_JSON
+    fi
     # Grab the latest version information.
     updateVersionsJSON
     # Figure out which worlds to update.

--- a/msctl
+++ b/msctl
@@ -541,8 +541,11 @@ updateVersionsJSON() {
     cp -p "$VERSIONS_JSON" "$VERSIONS_JSON.bak"
     # Delete the version_manifest.json file if it is old.
     find "$VERSIONS_JSON" -mmin +"$VERSIONS_DURATION" -delete
-    if [ ! -s $VERSIONS_JSON ]; then
-      printf "The version manifest was out of date, it has been removed.\n"
+    if [ -s $VERSIONS_JSON ]; then
+      printf "The cached copy of the version manifest is up to date.\n"
+      printf "Use the force-update option to ensure a new copy is downloaded.\n"
+    else
+      printf "The version manifest cache was out of date, it has been removed.\n"
     fi
   fi
   # Download the version_manifest.json file if it does not exist.

--- a/msctl
+++ b/msctl
@@ -2508,6 +2508,8 @@ case "$1" in
     # Handle the force option.
     if [ "$1" = "force-update" ]; then
       if [ -s $VERSIONS_JSON ]; then
+        # Make a backup copy of the version_manifest.json file.
+        cp -fp "$VERSIONS_JSON" "$VERSIONS_JSON.bak"
         printf "Removing cached version manifest.\n"
       fi
       rm -f $VERSIONS_JSON

--- a/msctl
+++ b/msctl
@@ -2506,7 +2506,10 @@ case "$1" in
   ;;
   update|force-update)
     # Handle the force option.
-    if [ "$(echo \"$1\" | cut -d '-' -f1)" = "force" ]; then
+    if [ "$1" = "force-update" ]; then
+      if [ -s $VERSIONS_JSON ]; then
+        printf "Removing cached version manifest.\n"
+      fi
       rm -f $VERSIONS_JSON
     fi
     # Grab the latest version information.


### PR DESCRIPTION
RFC: Rework the `version_manifest.json` update function so that we only try to download the file once each time the script is executed. Prior to this change the update code would run multiples times per execution of the script -- subsequent downloads would be skipped if the file was new enough (defined by VERSIONS_DURATION), but was a hacky solution.

Not all command line options require the version_manifest.json file to exist, so we might want to move the call to the new update function `updateVersionsJSON` elsewhere.

I also reduced the default duration of this file to 30 minutes.

This does not cover all of the requests in Issue #164, but it is a start.