### PR TITLE
mscs: use the set-home argument to sudo to fix $HOME

### DIFF
--- a/mscs
+++ b/mscs
@@ -31,5 +31,5 @@ MSCS_ARGS="-p $PROG -l $LOCATION -c $MSCS_DEFAULTS $@"
 if [ "$USER_NAME" = "$(whoami)" ]; then
   msctl $MSCS_ARGS
 else
-  sudo "PATH=$PATH" -u $USER_NAME msctl $MSCS_ARGS
+  sudo "PATH=$PATH" -u $USER_NAME --set-home msctl $MSCS_ARGS
 fi


### PR DESCRIPTION
Why testing I noticed that $HOME was mapping to my username rather than my `minecraft` user.  This fixes this.