### PR TITLE
Fixed incorrect mirror related paths

### DIFF
--- a/msctl
+++ b/msctl
@@ -1177,7 +1177,7 @@ watchLog() {
 # ---------------------------------------------------------------------------
 syncMirrorImage() {
   # Sync the world server.
-  $RSYNC -a --delete "$WORLDS_LOCATION/$1/$1/" "$WORLDS_LOCATION/$1/$1-original"
+  $RSYNC -a --delete "$WORLDS_LOCATION/$1/" "$WORLDS_LOCATION/$1-original"
   if [ $? -ne 0 ]; then
     printf "Error synchronizing mirror images for world $1.\n"
     exit 1
@@ -1216,13 +1216,13 @@ start() {
   mkdir -p "$WORLD_DIR"
   # If the original level exists but the actual level doesn't,
   # we probably restored a backup.
-  if [ -d "$WORLD_DIR/$1-original" ] && [ ! -e "$WORLD_DIR/$1" ] && [ ! -L "$WORLD_DIR/$1" ]; then
+  if [ -d "$WORLD_DIR-original" ] && [ ! -e "$WORLD_DIR" ] && [ ! -L "$WORLD_DIR" ]; then
     # Restore the original world files.
-    mv "$WORLD_DIR/$1-original" "$WORLD_DIR/$1"
+    mv "$WORLD_DIR-original" "$WORLD_DIR"
   fi;
   # Make sure that the level directory exists.
-  if [ ! -e "$WORLD_DIR/$1" ] && [ ! -L "$WORLD_DIR/$1" ]; then
-    mkdir -p "$WORLD_DIR/$1"
+  if [ ! -e "$WORLD_DIR" ] && [ ! -L "$WORLD_DIR" ]; then
+    mkdir -p "$WORLD_DIR"
   fi;
   # Make sure the EULA has been set to true.
   EULA=$(getEULAValue "$1")
@@ -1239,31 +1239,31 @@ start() {
     mkdir -p "$MIRROR_PATH"
     # If the symlink exists but the target doesn't, the
     # mirror was removed somehow. This is bad.
-    if [ -L "$WORLD_DIR/$1" ] && [ ! -d "$MIRROR_PATH/$1" ]; then
+    if [ -L "$WORLD_DIR" ] && [ ! -d "$MIRROR_PATH/$1" ]; then
       # Remove the symlink to the mirror image.
-      rm -f "$WORLD_DIR/$1"
+      rm -f "$WORLD_DIR"
       # Restore the original world files.
-      mv "$WORLD_DIR/$1-original" "$WORLD_DIR/$1"
+      mv "$WORLD_DIR-original" "$WORLD_DIR"
       # Send notification.
       printf "Warning, the mirror for %s was removed, restored latest world.\n" $1
     fi;
     # If the symlink still exists, the server was stopped outside of mscs.
     # SO DONT RESET THE MIRROR, just keep using it.
-    if [ ! -L "$WORLD_DIR/$1" ]; then
+    if [ ! -L "$WORLD_DIR" ]; then
       # Remove the mirror directory just in case.
       rm -Rf "$MIRROR_PATH/$1"
       # Copy the world files over to the mirror.
-      cp -a "$WORLD_DIR/$1" "$MIRROR_PATH/$1"
+      cp -a "$WORLD_DIR" "$MIRROR_PATH/$1"
       if [ $? -ne 0 ]; then
         printf "Error copying world data, could not copy to %s.\n" $MIRROR_PATH/$1
         exit 1
       fi
       # Remove the world file backup directory just in case.
-      rm -Rf "$WORLD_DIR/$1-original"
+      rm -Rf "$WORLD_DIR-original"
       # Rename the original world file directory.
-      mv "$WORLD_DIR/$1" "$WORLD_DIR/$1-original"
+      mv "$WORLD_DIR" "$WORLD_DIR-original"
       # Create a symlink from the world file directory's original name to the mirrored files.
-      ln -s "$MIRROR_PATH/$1" "$WORLD_DIR/$1"
+      ln -s "$MIRROR_PATH/$1" "$WORLD_DIR"
     fi
   fi
   # Change to the world's directory.
@@ -1321,14 +1321,14 @@ stop() {
     sleep 1
   done;
   # Synchronize the mirror image of the world prior to closing, if required.
-  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1/$1" ] && [ -d "$MIRROR_PATH/$1" ]; then
+  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1" ] && [ -d "$MIRROR_PATH/$1" ]; then
     syncMirrorImage $1
     # Remove the symlink to the world-file mirror image.
-    rm -f "$WORLDS_LOCATION/$1/$1"
+    rm -f "$WORLDS_LOCATION/$1"
     # Remove the world-file mirror image folder.
     rm -Rf "$MIRROR_PATH/$1"
     # Move the world files back to their original path name.
-    mv "$WORLDS_LOCATION/$1/$1-original" "$WORLDS_LOCATION/$1/$1"
+    mv "$WORLDS_LOCATION/$1-original" "$WORLDS_LOCATION/$1"
   fi
   # Remove the PID file for the world server.
   rm -f "$WORLDS_LOCATION/$1.pid"
@@ -1371,7 +1371,7 @@ worldBackup() {
   fi
   # Synchronize the mirror image of the world prior to closing, if
   # required.
-  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1/$1" ] && [ -d "$MIRROR_PATH/$1" ]; then
+  if [ $ENABLE_MIRROR -eq 1 ] && [ -L "$WORLDS_LOCATION/$1" ] && [ -d "$MIRROR_PATH/$1" ]; then
     syncMirrorImage $1
   fi
   EXCLUDE_OPTION=" \
@@ -1380,8 +1380,8 @@ worldBackup() {
     --exclude $WORLDS_LOCATION/$1/logs/latest.log \
   "
   # Determine if we need to exclude the mirrored symlink or not
-  if [ -L "$WORLDS_LOCATION/$1/$1" ]; then
-    EXCLUDE_OPTION="$EXCLUDE_OPTION --exclude $WORLDS_LOCATION/$1/$1"
+  if [ -L "$WORLDS_LOCATION/$1" ]; then
+    EXCLUDE_OPTION="$EXCLUDE_OPTION --exclude $WORLDS_LOCATION/$1"
   fi
   # Create the backup.
   if ! $RDIFF_BACKUP -v5 --print-statistics $EXCLUDE_OPTION "$WORLDS_LOCATION/$1" "$BACKUP_LOCATION/$1" >> "$BACKUP_LOG"; then
@@ -1572,7 +1572,7 @@ overviewer() {
   if [ ! -e $SETTINGS_FILE ]; then
     # Use the backup location so we minimize the time the server isn't saving
     # data.
-    printf "worlds['$1'] = '$BACKUP_LOCATION/$1/$1'\n\n" > $SETTINGS_FILE
+    printf "worlds['$1'] = '$BACKUP_LOCATION/$1'\n\n" > $SETTINGS_FILE
     printf "renders['overworld-render'] = {\n" >> $SETTINGS_FILE
     printf "  'world': '$1',\n" >> $SETTINGS_FILE
     printf "  'title': 'Overworld',\n" >> $SETTINGS_FILE


### PR DESCRIPTION
Many of the paths have duplicate server (world) names.

Example:
WORLD_DIR="$WORLDS_LOCATION/$1"
Then using: $WORLD_DIR/$1
Resulting in: mscs/worlds/MyServer/MyServer

This prevented the server being copied to the ramdisk, completely breaking the feature. The server would however continue to run from the normal location making it appear to work.