### PR TITLE
Fix overviewer mapping when world mirroring is enabled

### DIFF
--- a/msctl
+++ b/msctl
@@ -1630,9 +1630,9 @@ overviewer() {
   updateClientSoftware "$1"
   # Create a default Overviewer settings file if it is missing.
   if [ ! -e $SETTINGS_FILE ]; then
-    # Use the backup location so we minimize the time the server isn't saving
-    # data.
-    printf "worlds['$1'] = '$BACKUP_LOCATION/$1/$1'\n\n" >$SETTINGS_FILE
+    # Use the backup location so we minimize the time the server isn't saving data.
+    printf "import os\n\n" >$SETTINGS_FILE
+    printf "worlds['$1'] = '$BACKUP_LOCATION/$1/$1-original' if os.path.exists('$BACKUP_LOCATION/$1/$1-original') else '$BACKUP_LOCATION/$1/$1'\n\n" >>$SETTINGS_FILE
     printf "renders['overworld-render'] = {\n" >>$SETTINGS_FILE
     printf "  'world': '$1',\n" >>$SETTINGS_FILE
     printf "  'title': 'Overworld',\n" >>$SETTINGS_FILE


### PR DESCRIPTION
When a backup is made of a server with world mirroring enabled, a '-original' postfix is added to the world name, causing mapping to fail. Adding this postfix to the config manually will not solve the issue, as backups made when the server is off will not include this postfix. Detecting the appropriate world when mapping starts will fix the issue, and will not affect servers without world mirroring enabled.