### PR TITLE
fix test for getServerCommand

### DIFF
--- a/tests/mscs-jvm-args.sh
+++ b/tests/mscs-jvm-args.sh
@@ -33,7 +33,7 @@ getServerVersion () {
 
 # verify getServerCommand returns correct jvm args
 got=$(getServerCommand $testworld)
-if printf $got | grep -qs -- "$want"; then
+if ! printf "$got" | grep -qs -- "$want"; then
     terr "getServerCommand did not return the expected command"
     terr got $got
     terr want substring $want


### PR DESCRIPTION
I noticed an error in this test after the prior PR was already closed.


```
jeremys@skynet> printf $got
/usr/bin/java

jeremys@skynet> printf "$got"
/usr/bin/java -Xms128M -Xmx2048M -Dtesting-the-jvmargs -jar /home/jeremys/mscs/server/minecraft_server.fakedVersion.jar nogui
```