### PR TITLE
Add new line after each server listed

### DIFF
--- a/msctl
+++ b/msctl
@@ -2761,6 +2761,7 @@ case "$COMMAND" in
             printf "    $PROP="
             getServerPropertiesValue "$WORLD" "$PROP" ""
           done
+          printf '\n'
         done
         ;;
     esac


### PR DESCRIPTION
This fixes the output for the 'list' command so that a new line is added after the property listing for each server.