### PR TITLE
Wait until query port opens before attempting to query

### DIFF
--- a/msctl
+++ b/msctl
@@ -1798,7 +1798,7 @@ querySendPacket() {
     '
   # If the response is empty and the query.in and query.out files have NOT been created,
   # the world is still starting up and the status query will return as such. 
-  # See lines 1987-1989.
+  # See lines 1985-1987.
 
   # If the response is empty and the query.in and query.out files HAVE been created, 
   # something went wrong. We try restarting the query handler again.

--- a/msctl
+++ b/msctl
@@ -1737,7 +1737,7 @@ queryStart() {
   # Wait until the query port is open before creating the query files
   # and establishing the tail process.
   nohup sh -c "
-    while ! nc -u -z $SERVER_IP $QUERY_PORT; do
+    while ! echo | $SOCAT - UDP-CONNECT:$SERVER_IP:$QUERY_PORT >/dev/null 2>&1; do
       sleep 0.1
     done;
     printf '' >\"$WORLD_DIR/query.in\"

--- a/msctl
+++ b/msctl
@@ -1731,22 +1731,20 @@ queryStart() {
   SERVER_PID=$(getJavaPID $1)
   # Delete any old query.in or query.out buffer files.
   rm -Rf "$WORLD_DIR/query.in" "$WORLD_DIR/query.out"
-  # Initialize the query.in and query.out buffer files.
-  printf '' >"$WORLD_DIR/query.in"
-  printf '' >"$WORLD_DIR/query.out"
   # Start a tail process to watch for changes to the query.in file to pipe
   # to the Minecraft query server via socat.  The response from the query
-  # server is piped into the query.out file.  Give the server a moment to
-  # start before initializing the Query handler.
+  # server is piped into the query.out file.
+  # Wait until the query port is open before creating the query files
+  # and establishing the tail process.
   nohup sh -c "
-    sleep 1;
+    while ! nc -u -z $SERVER_IP $QUERY_PORT; do
+      sleep 0.1
+    done;
+    printf '' >\"$WORLD_DIR/query.in\"
+    printf '' >\"$WORLD_DIR/query.out\"
     tail -f --pid=$SERVER_PID \"$WORLD_DIR/query.in\" |
     $SOCAT - UDP:$SERVER_IP:$QUERY_PORT > \"$WORLD_DIR/query.out\"
   " >/dev/null 2>&1 &
-  # Verify the connection to the query server worked.
-  if [ $? -ne 0 ]; then
-    printf "Error connecting to the query server.\n"
-  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1791,13 +1789,20 @@ querySendPacket() {
       print $hex;
     ' $WORLD_DIR/query.out)
   fi
+  # If the response is not empty, return the response 
+  # in the format requested.
   if [ -n "$RESPONSE" ]; then
-    # Return the response in the format requested.
     $PERL -e '
       $packed = join "", map { pack ("C", hex($_)) } ("'$RESPONSE'" =~ /(..)/g);
       printf "%s\n", join "\t", unpack ("'$4'", $packed);
     '
-  else
+  # If the response is empty and the query.in and query.out files have NOT been created,
+  # the world is still starting up and the status query will return as such. 
+  # See lines 1987-1989.
+
+  # If the response is empty and the query.in and query.out files HAVE been created, 
+  # something went wrong. We try restarting the query handler again.
+  elif [ -z "$RESPONSE" ] && [ -e "$WORLD_DIR/query.in" ] && [ -e "$WORLD_DIR/query.out" ]; then
     ps a | grep socat | grep "$1" | grep tail >/dev/null || queryStart "$1"
   fi
 }
@@ -1974,8 +1979,12 @@ worldStatus() {
         done
         printf "    Players: %s.\n" "$PLAYERS"
       fi
-    elif [ "$(getServerPropertiesValue $1 'enable-query')" = "true" ]; then
+    elif [ "$(getServerPropertiesValue $1 'enable-query')" = "true" ] && 
+      [ -e "$WORLD_DIR/query.in" ] && [ -e "$WORLD_DIR/query.out" ]; then
       printf "running (query server offline).\n"
+    elif [ "$(getServerPropertiesValue $1 'enable-query')" = "true" ] && 
+      [ ! -e "$WORLD_DIR/query.in" ] && [ ! -e "$WORLD_DIR/query.out" ]; then
+      printf "world starting up.\n"
     else
       printf "running.\n"
     fi


### PR DESCRIPTION
Hi,

Attempting to query a world before the query port is open results in the socat "connection" (not really a connection since it's UDP) being dropped. Additionally, the code in lines 1734-1736 is never triggered -- even if the query connection failed, the error message will never print. 
```
  # Verify the connection to the query server worked.	
  if [ $? -ne 0 ]; then	
    printf "Error connecting to the query server.\n"	
  fi
````
Subsequent queries to the world will result in a `running (query server offline)` message because the socat connection will never be re-established. 

Isssue #232 fixes this issue downstream by having an `else` clause that executes the `queryStart()` function again. However, this is only triggered when the socat connection has dropped at least once, so it's a bit inefficient.

This pull request fixes the root issue by waiting until the minecraft query port is open through the use of netcat (I assume most linux distros ship with netcat so this shouldn't be a dependency issue, but if there's a way to do the same thing with socat than that may be better).  Once this query port is detected as open, it creates the `query.in` and `query.out` files and establishes the socat connection. By doing it this way, we can detect if a) the world is still starting and that's why we're not getting queries or b) there is something actually wrong with the query server even though the port is open (which is what is implied in Issue #169, though in my testing, this has never happened). 

I'm leaving the code in from #232 (thanks to @sheimer for the PR ! ) as a redundancy in case the query server drops even after the query ports are open (again, as is implied in #169). 


