### PR TITLE
Add notice when attempting to start/stop an already started/stopped world

### DIFF
--- a/msctl
+++ b/msctl
@@ -2416,13 +2416,13 @@ case "$COMMAND" in
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
           if serverRunning "$arg"; then
-            printf "Unable to start the requested world(s): world '$arg' already running.\n"
+            printf "Unable to start the requested worlds: world '$arg' already running.\n"
             exit 1
           else
             WORLDS="$WORLDS $arg"
           fi
         else
-          printf "World '$arg' not recognized or disabled.\n"
+          printf "Unable to start the requested worlds: world '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2444,13 +2444,13 @@ case "$COMMAND" in
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
           if ! serverRunning "$arg"; then
-            printf "Unable to stop the requested world(s): world '$arg' already stopped.\n"
+            printf "Unable to stop the requested worlds: world '$arg' already stopped.\n"
             exit 1
           else
             WORLDS="$WORLDS $arg"
           fi
         else
-          printf "World '$arg' not recognized or disabled.\n"
+          printf "Unable to stop the requested worlds: world '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2497,7 +2497,7 @@ case "$COMMAND" in
         if isWorldEnabled "$arg"; then
           WORLDS="$WORLDS $arg"
         else
-          printf "World '$arg' not recognized or disabled.\n"
+          printf "Unable to restart the requested worlds: world '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi

--- a/msctl
+++ b/msctl
@@ -2415,9 +2415,14 @@ case "$COMMAND" in
       WORLDS=''
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
-          WORLDS="$WORLDS $arg"
+          if serverRunning "$arg"; then
+            printf "Unable to start the requested world(s): world '$arg' already running.\n"
+            exit 1
+          else
+            WORLDS="$WORLDS $arg"
+          fi
         else
-          printf "World '$arg' not recognized.\n"
+          printf "World '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2438,9 +2443,14 @@ case "$COMMAND" in
     if [ "$#" -ge 1 ]; then
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
-          WORLDS="$WORLDS $arg"
+          if ! serverRunning "$arg"; then
+            printf "Unable to stop the requested world(s): world '$arg' already stopped.\n"
+            exit 1
+          else
+            WORLDS="$WORLDS $arg"
+          fi
         else
-          printf "World '$arg' not recognized.\n"
+          printf "World '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi

--- a/msctl
+++ b/msctl
@@ -2421,8 +2421,12 @@ case "$COMMAND" in
           else
             WORLDS="$WORLDS $arg"
           fi
+        elif isWorldDisabled "$arg"; then
+            printf "Unable to start the requested worlds: world '$arg' is disabled.\n"
+            printf "Please enable the world first with '$PROG enable $arg'.\n"
+            exit 1
         else
-          printf "Unable to start the requested worlds: world '$arg' not recognized or disabled.\n"
+          printf "Unable to start the requested worlds: world '$arg' not recognized.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2449,8 +2453,12 @@ case "$COMMAND" in
           else
             WORLDS="$WORLDS $arg"
           fi
+        elif isWorldDisabled "$arg"; then
+            printf "Unable to stop the requested worlds: world '$arg' is disabled.\n"
+            printf "Please enable the world first with '$PROG enable $arg'.\n"
+            exit 1
         else
-          printf "Unable to stop the requested worlds: world '$arg' not recognized or disabled.\n"
+          printf "Unable to stop the requested worlds: world '$arg' not recognized.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2496,8 +2504,12 @@ case "$COMMAND" in
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
           WORLDS="$WORLDS $arg"
+        elif isWorldDisabled "$arg"; then
+            printf "Unable to start the requested worlds: world '$arg' is disabled.\n"
+            printf "Please enable the world first with '$PROG enable $arg'.\n"
+            exit 1
         else
-          printf "Unable to restart the requested worlds: world '$arg' not recognized or disabled.\n"
+          printf "Unable to restart the requested worlds: world '$arg' not recognized.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi
@@ -2618,23 +2630,30 @@ case "$COMMAND" in
       printf "World not found, unable to delete world '$1'.\n"
       exit 1
     fi
-    printf "Deleting Minecraft world: $1"
-    if serverRunning "$1"; then
-      # If the world server has users logged in, announce that the world is
-      # being deleted.
-      if [ $(queryNumUsers "$1") -gt 0 ]; then
-        sendCommand "$1" "say The server admin is deleting this world."
-        sendCommand "$1" "say The server will be deleted in 1 minute..."
-        sleep 60
-        sendCommand "$1" "say The server is now shutting down."
+    printf "Are you sure you wish to delete world '$1'? (y/n): "
+    read answer
+    if [ "$answer" = "${answer#[Yy]}" ]; then
+        printf "Aborted.\n"
+        exit 1
+    else
+      printf "Deleting Minecraft world: $1"
+      if serverRunning "$1"; then
+        # If the world server has users logged in, announce that the world is
+        # being deleted.
+        if [ $(queryNumUsers "$1") -gt 0 ]; then
+          sendCommand "$1" "say The server admin is deleting this world."
+          sendCommand "$1" "say The server will be deleted in 1 minute..."
+          sleep 60
+          sendCommand "$1" "say The server is now shutting down."
+        fi
+        # Stop the world server.
+        stop "$1"
+        sleep 5
       fi
-      # Stop the world server.
-      stop "$1"
-      sleep 5
+      # Delete the world.
+      deleteWorld "$1"
+      printf ".\n"
     fi
-    # Delete the world.
-    deleteWorld "$1"
-    printf ".\n"
     ;;
   disable)
     # Get list of enabled worlds.

--- a/msctl
+++ b/msctl
@@ -2497,7 +2497,7 @@ case "$COMMAND" in
         if isWorldEnabled "$arg"; then
           WORLDS="$WORLDS $arg"
         else
-          printf "World '$arg' not recognized.\n"
+          printf "World '$arg' not recognized or disabled.\n"
           printf "  Usage:  $PROG $COMMAND <world1> <world2> <...>\n"
           exit 1
         fi


### PR DESCRIPTION
Attempting to start an already started world or stop an already stopped world will only display a period ("."), such as below:

````
$ mscs status
Minecraft Server Status:
  test: running version 1.15.2 (2 of 20 users online).
    Process ID: 5160.
    Memory used: 2538068 kB.
  cannon: not running.

$ mscs start test
The cached copy of the version manifest is up to date.
Use the force-update option to ensure a new copy is downloaded.
Starting Minecraft Server:.

$ mscs stop cannon
Stopping Minecraft Server:.

````

This patch notifies the user when they attempt to start or stop an already started/stopped world. If the user tries to start/stop multiple worlds and one already is started/stopped, then the entire command will exit and no worlds will be started or stopped (same behavior when user tries to start/stop/restart worlds and one world doesn't exist).

````
$ mscs status
Minecraft Server Status:
  test: running version 1.15.2 (2 of 20 users online).
    Process ID: 5160.
    Memory used: 2538068 kB.
  cannon: not running.

$ mscs start test
The cached copy of the version manifest is up to date.
Use the force-update option to ensure a new copy is downloaded.
Unable to start the requested worlds: world 'test' already running.

$ mscs stop cannon
Unable to stop the requested worlds: world 'cannon' already stopped.

$ mscs start test cannon
The cached copy of the version manifest is up to date.
Use the force-update option to ensure a new copy is downloaded.
Unable to start the requested worlds: world 'test' already running.

$ mscs stop test cannon
Unable to stop the requested worlds: world 'cannon' already stopped.
````

Additionally, right now when a user tries to start/stop/restart a world that doesn't exist, it will say "World not recognized . I changed the warnings to "World not recognized **or disabled**" since disabled worlds won't be recognized either (since the worlds are being checked with the `isWorldEnabled` function). 