### PR TITLE
Add automatic crash detection and restarts

### DIFF
--- a/msctl
+++ b/msctl
@@ -2323,7 +2323,7 @@ fi
 #   mscs-default-maximum-memory     - Default maximum amount of memory for a world server.
 #   mscs-default-server-location    - Default location of the server .jar file.
 #   mscs-default-server-command     - Default command to run for a world server.
-#   mscs-enable-restart-after-crash - Enable the option to restart worlds after crash detected (default enabled).
+#   mscs-enable-restart-after-crash - Enable the option to restart the server after crash detected (default enabled).
 #   mscs-backup-location            - Location to store backup files.
 #   mscs-backup-log                 - Location of the backup log file.
 #   mscs-backup-duration            - Length in days that backups survive.

--- a/msctl
+++ b/msctl
@@ -1331,9 +1331,11 @@ serverMonitor() {
       # Verify that the server restarted successfully. 
       if [ $? -eq 0 ]; then
         printf "[$(timestamp)] [INFO]: Server monitoring resumed for $1. Server PID: $(getJavaPID $1). Monitor PID: $MONITOR_PID.\n"
-        printf "    $1 automatically restarted from a crash on $(timestamp).\n" > "$LAST_START_STATUS_LOG"
-        printf "    See $WORLD_DIR/logs/mscs.monitor.log and\n" >> "$LAST_START_STATUS_LOG"
-        printf "    $WORLD_DIR/crash_reports/ for more information.\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $1 automatically restarted from a crash (or in-game stop command)\n" > "$LAST_START_STATUS_LOG"
+        printf "    on $(timestamp). See\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/logs/mscs.monitor.log and\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/crash_reports/ and\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/logs/ for more information.\n" >> "$LAST_START_STATUS_LOG"
       else
         printf "[$(timestamp)] [ERROR]: Failed to restart $1.\n" 
         stopServerMonitor $1
@@ -2323,7 +2325,7 @@ fi
 #   mscs-default-maximum-memory     - Default maximum amount of memory for a world server.
 #   mscs-default-server-location    - Default location of the server .jar file.
 #   mscs-default-server-command     - Default command to run for a world server.
-#   mscs-enable-restart-after-crash - Enable the option to restart the server after crash detected (default enabled).
+#   mscs-enable-restart-after-crash - Enable the option to restart server after crash detected (default enabled).
 #   mscs-backup-location            - Location to store backup files.
 #   mscs-backup-log                 - Location of the backup log file.
 #   mscs-backup-duration            - Length in days that backups survive.

--- a/msctl
+++ b/msctl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ---------------------------------------------------------------------------
-# Copyright (c) 2011-2016, Jason M. Wood <sandain@hotmail.com>
+# Copyright (c) 2011-2020, Jason M. Wood <sandain@hotmail.com>
 #
 # All rights reserved.
 #
@@ -268,6 +268,11 @@ mscs_defaults() {
 ; provides access to the arguments for the world server selected.
 # mscs-default-server-command=\$JAVA -Xms\$INITIAL_MEMORY -Xmx\$MAXIMUM_MEMORY -jar \$SERVER_LOCATION/\$SERVER_JAR \$SERVER_ARGS
 
+; Enable the option to restart the server after a crash is detected.
+; 0 - Restart after crash (default).
+; 1 - Do not restart after crash.
+# mscs-enable-restart-after-crash=0
+
 ; Location to store backup files.
 # mscs-backup-location=/opt/mscs/backups
 
@@ -346,9 +351,9 @@ getJavaMemory() {
 serverRunning() {
   # Try to determine if the world is running.
   if [ $(getJavaPID "$1") -gt 0 ]; then
-    return 0
+    echo 0
   else
-    return 1
+    echo 1
   fi
 }
 
@@ -1263,6 +1268,120 @@ serverConsole() {
 }
 
 # ---------------------------------------------------------------------------
+# Retrieve the timestamp.
+#
+# @return The current date and time.
+# ---------------------------------------------------------------------------
+timestamp() {
+  date +"%Y-%m-%d_%H-%M-%S"
+}
+
+# ---------------------------------------------------------------------------
+# Stop the server monitor.
+#
+# @param 1 The world server to stop.
+# ---------------------------------------------------------------------------
+stopServerMonitor() {
+  local WORLD_DIR MONITOR_LOG MONITOR_PID MONITOR_LOCK_FILE ACQUIRED_LOCK
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  MONITOR_LOCK_FILE="$WORLD_DIR/monitor.lock"
+  # Check if server monitor instance currently running.
+  (
+  flock -n 9
+  ACQUIRED_LOCK=$?
+  if [ "$ACQUIRED_LOCK" -eq 1 ]; then # Server monitor is running.
+    printf "[$(timestamp)] [INFO]: Stop command received for server monitor. Attempting to kill server monitor...\n" >> "$MONITOR_LOG"
+    # Kill the server monitor.
+    kill -9 $(cat $MONITOR_PID)
+    # Verify it was actually killed.
+    if [ $? -eq 1 ]; then
+      printf "[$(timestamp)] [ERROR]: Unable to kill monitor process.\n" >> "$MONITOR_LOG"
+      exit 1
+    else 
+      printf "[$(timestamp)] [INFO]: Server monitor process killed sucessfully.\n" >> "$MONITOR_LOG"
+      # Remove the monitor PID file. 
+      rm -f "$WORLD_DIR/monitor.pid"
+    fi
+  fi
+  ) 9>"$MONITOR_LOCK_FILE"
+}
+# ---------------------------------------------------------------------------
+# Run the server monitor.
+#
+# @param 1 The world server to monitor.
+# ---------------------------------------------------------------------------
+serverMonitor() {
+  local WORLD_DIR MONITOR_LOG SERVER_LOG LAST_START_STATUS_LOG MONITOR_PID GREP_STOP
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  SERVER_LOG="$WORLD_DIR/logs/latest.log"
+  LAST_START_STATUS_LOG="$WORLD_DIR/logs/last-start-status.log"
+  MONITOR_PID=$(cat "$WORLD_DIR/monitor.pid")
+  touch $LAST_START_STATUS_LOG
+
+  printf "[$(timestamp)] [INFO]: Server monitoring started for $1. Server PID: $(getJavaPID $1). Monitor PID: $MONITOR_PID.\n"
+  # Run monitor until the server is stopped and the PID file is removed (i.e. clean shutdown).
+  until [ $(serverRunning $1) -eq 1 ] && [ ! -f "$WORLDS_LOCATION/$1.pid" ]; do
+    # If server isn't running and server PID file exists, server crashed.
+    if [ $(serverRunning $1) -eq 1 ] && [ -f "$WORLDS_LOCATION/$1.pid" ]; then
+      printf "[$(timestamp)] [WARN]: Server crash detected. Attempting to restart $1...\n"
+      start $1
+      # Verify that the server restarted successfully. 
+      if [ $? -eq 0 ]; then
+        printf "[$(timestamp)] [INFO]: Server monitoring resumed for $1. Server PID: $(getJavaPID $1). Monitor PID: $MONITOR_PID.\n"
+        printf "    $1 automatically restarted from a crash on $(timestamp).\n" > "$LAST_START_STATUS_LOG"
+        printf "    See $WORLD_DIR/logs/mscs.monitor.log and\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/crash_reports/ for more information.\n" >> "$LAST_START_STATUS_LOG"
+      else
+        printf "[$(timestamp)] [ERROR]: Failed to restart $1.\n" 
+        stopServerMonitor $1
+      fi
+    # If server is running and server PID file doesn't exist, error occurred.
+    elif [ $(serverRunning $1) -eq 0 ] && [ ! -f "$WORLDS_LOCATION/$1.pid" ]; then
+      printf "[$(timestamp)] [ERROR]: PID file doesn't exist.\n"
+      stopServerMonitor $1
+    fi 
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Start the server monitor.
+#
+# @param 1 The world server to monitor.
+# ---------------------------------------------------------------------------
+startServerMonitor() {
+  local WORLD_DIR MONITOR_LOG MONITOR_PID MONITOR_LOCK_FILE ACQUIRED_LOCK
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  MONITOR_LOCK_FILE="$WORLD_DIR/monitor.lock"
+
+  # Verify option is enabled.
+  if [ $ENABLE_RESTART_AFTER_CRASH -eq 0 ]; then
+    # Verify that there is no monitor instance currently running.
+    (
+    flock -n 9
+    ACQUIRED_LOCK=$?
+    if [ "$ACQUIRED_LOCK" -eq 0 ]; then # Server monitor doesn't exist.
+      # Delete old log file greater than $LOG_DURATION, if it exists.
+      if [ -f "$MONITOR_LOG" ]; then
+        if [ "$LOG_DURATION" -gt 0 ]; then
+          find "$MONITOR_LOG" -type f -mtime +"$LOG_DURATION" -delete
+        fi
+      fi
+      # Run the server monitor.
+      # Nohup does not allow you to pass functions. However, the code below mimics nohup behavior by doing the following:
+        # Start subshell, ignore HUP signal, redirect stdin to /dev/null, redirect stdout and stderr to log file, run in background.
+      # Also store the PID of this process for later use.
+      ( trap "true" HUP ; pid=$(exec sh -c 'echo "$PPID"'); echo $pid > "$MONITOR_PID"; serverMonitor $1 ) </dev/null 2>&1 1>>"$MONITOR_LOG" & 
+    fi
+    ) 9>"$MONITOR_LOCK_FILE"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Start the world server.  Generate the appropriate environment for the
 # server if it doesn't already exist.
 #
@@ -1366,6 +1485,8 @@ start() {
   fi
   # Create a PID file for the world server.
   echo $PID >"$WORLDS_LOCATION/$1.pid"
+  # Start the server crash monitor, if enabled.
+  startServerMonitor $1
 }
 
 # ---------------------------------------------------------------------------
@@ -1374,11 +1495,13 @@ start() {
 # @param 1 The world server to stop.
 # ---------------------------------------------------------------------------
 stop() {
+  # Stop the server monitor if it is running.
+  stopServerMonitor $1
   # Tell the server to stop.
   sendCommand $1 "stop"
   sendCommand $1 "end"
   # Wait for the server to shut down.
-  while serverRunning $1; do
+  while [ $(serverRunning $1) -eq 0 ]; do
     sleep 1
   done
   # Synchronize the mirror image of the world prior to closing, if required.
@@ -1402,12 +1525,14 @@ stop() {
 # ---------------------------------------------------------------------------
 forceStop() {
   local WAIT
+  # Stop the server monitor if it is running.
+  stopServerMonitor $1
   # Try to stop the server cleanly first.
   sendCommand $1 "stop"
   sendCommand $1 "end"
   # Wait for the server to shut down.
   WAIT=0
-  while serverRunning $1 && [ $WAIT -le 20 ]; do
+  while [ $(serverRunning $1) -eq 0 ] && [ $WAIT -le 20 ]; do
     WAIT=$(($WAIT + 1))
     sleep 1
   done
@@ -1662,7 +1787,7 @@ overviewer() {
     printf "outputdir = '$MAPS_LOCATION/$1'\n" >>$SETTINGS_FILE
   fi
   # Announce the mapping of the world to players if the world is running.
-  if serverRunning $1; then
+  if [ $(serverRunning $1) -eq 0 ]; then
     if [ $VERSION_TEST -ge 0 ]; then
       sendCommand $1 'tellraw @a {
         "text" : "",
@@ -1691,7 +1816,7 @@ overviewer() {
   $OVERVIEWER_BIN --config=$SETTINGS_FILE >>$LOG_FILE 2>&1
   $OVERVIEWER_BIN --config=$SETTINGS_FILE --genpoi >>$LOG_FILE 2>&1
   # Announce the location to access the world map to players.
-  if serverRunning $1; then
+  if [ $(serverRunning $1) -eq 0 ]; then
     if [ $VERSION_TEST -ge 0 ]; then
       sendCommand $1 'tellraw @a {
         "text" : "",
@@ -1801,9 +1926,9 @@ querySendPacket() {
       printf "%s\n", join "\t", unpack ($format, $packed);
     ' -- -response="$RESPONSE" -format="$4"
 
-  # If the response is empty and the query.in and query.out files have NOT been created,
+  # If the response is empty and both the query.in and query.out files have NOT been created,
   # the world is still starting up and the status query will return as such.
-  # See lines 1985-1987.
+  # See the worldStatus function.
 
   # If the response is empty and the query.in and query.out files HAVE been created,
   # something went wrong. We try restarting the query handler again.
@@ -1967,8 +2092,11 @@ queryNumUsers() {
 # @param 1 The world server of interest.
 # ---------------------------------------------------------------------------
 worldStatus() {
-  local STATUS NUM MAX PLAYERS COUNTER VERSION
-  if serverRunning $1; then
+  local WORLD_DIR LAST_START_STATUS_LOG MONITOR_PID STATUS NUM MAX PLAYERS COUNTER VERSION 
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  LAST_START_STATUS_LOG="$WORLD_DIR/logs/last-start-status.log"
+  if [ $(serverRunning $1) -eq 0 ]; then
     STATUS=$(queryDetailedStatus $1)
     if [ -n "$STATUS" ]; then
       NUM=$(printf "%s" "$STATUS" | cut -f 19)
@@ -1996,7 +2124,18 @@ worldStatus() {
     fi 
     printf "    Memory used: $(getJavaMemory "$1" | awk '{$1=int(100 * $1/1024/1024)/100"GB";}{ print;}')"
     printf " ($(getMSCSValue "$1" "mscs-maximum-memory" "$DEFAULT_MAXIMUM_MEMORY" | rev | cut -c 2- | rev | awk '{$1=int($1/1024)"GB";}{ print;}') allocated).\n"
-    printf "    Process ID: %d.\n" $(getJavaPID "$1")
+    printf "    Server PID: %d.\n" $(getJavaPID "$1")
+    # Display crash monitor PID if it's running (i.e. monitor.pid file exists and not empty).
+    if [ -f "$MONITOR_PID" ] && [ -s "$MONITOR_PID" ]; then
+      printf "    Crash Monitor PID: $(cat $MONITOR_PID)\n"
+    fi
+    # If the last-status log exists and not empty, then last restart was from a crash.
+    # Display notice once.
+    if [ -f "$LAST_START_STATUS_LOG" ] && [ -s "$LAST_START_STATUS_LOG" ]; then
+      printf "$(cat $LAST_START_STATUS_LOG)\n"
+      # Remove it so user doesn't see it next time they run the status command.
+      rm -f $LAST_START_STATUS_LOG
+    fi
   elif [ "$(getMSCSValue $1 'mscs-enabled')" = "false" ]; then
     printf "disabled.\n"
   else
@@ -2012,7 +2151,7 @@ worldStatus() {
 # ---------------------------------------------------------------------------
 worldStatusJSON() {
   local RUNNING QUERY PID MEMORY
-  if serverRunning $1; then
+  if [ $(serverRunning $1) -eq 0 ]; then
     RUNNING="true"
     QUERY="$(queryDetailedStatusJSON $1)"
     PID="$(getJavaPID $1)"
@@ -2159,45 +2298,43 @@ fi
 if [ ! -s "$MSCS_DEFAULTS" ]; then
   mscs_defaults >$MSCS_DEFAULTS
 fi
-# Default values in the script can be overridden by adding certain key/value
-# pairs to one of the mscs.defaults files mentioned above. Default values in
-# the script will be used unless overridden in one these files.
-#
 # The following keys are available:
-#   mscs-location                - Location of the mscs files.
-#   mscs-worlds-location         - Location of world files.
-#   mscs-versions-url            - URL to download the version_manifest.json file.
-#   mscs-versions-json           - Location of the version_manifest.json file.
-#   mscs-versions-duration       - Duration (in minutes) to keep the version_manifest.json file before updating.
-#   mscs-lockfile-duration       - Duration (in minutes) to keep lock files before removing.
-#   mscs-detailed-listing        - Properties to return for detailed listings.
-#   mscs-default-world           - Default world name.
-#   mscs-default-port            - Default Port.
-#   mscs-default-ip              - Default IP address.
-#   mscs-default-version-type    - Default version type (release or snapshot).
-#   mscs-default-client-version  - Default version of the client software.
-#   mscs-default-client-jar      - Default .jar file for the client software.
-#   mscs-default-client-url      - Default download URL for the client software.
-#   mscs-default-client-location - Default location of the client .jar file.
-#   mscs-default-server-version  - Default version of the server software.
-#   mscs-default-jvm-args        - Default arguments for the JVM.
-#   mscs-default-server-jar      - Default .jar file for the server software.
-#   mscs-default-server-url      - Default download URL for the server software.
-#   mscs-default-server-args     - Default arguments for a world server.
-#   mscs-default-initial-memory  - Default initial amount of memory for a world server.
-#   mscs-default-maximum-memory  - Default maximum amount of memory for a world server.
-#   mscs-default-server-location - Default location of the server .jar file.
-#   mscs-default-server-command  - Default command to run for a world server.
-#   mscs-backup-location         - Location to store backup files.
-#   mscs-backup-log              - Lcation of the backup log file.
-#   mscs-backup-duration         - Length in days that backups survive.
-#   mscs-log-duration            - Length in days that logs survive.
-#   mscs-enable-mirror           - Enable the mirror option by default for worlds (default disabled).
-#   mscs-mirror-path             - Default path for the mirror files.
-#   mscs-overviewer-bin          - Location of Overviewer.
-#   mscs-overviewer-url          - URL for Overviewer.
-#   mscs-maps-location           - Location of Overviewer generated map files.
-#   mscs-maps-url                - URL for accessing Overviewer generated maps.
+#   mscs-location                   - Location of the mscs files.
+#   mscs-worlds-location            - Location of world files.
+#   mscs-versions-url               - URL to download the version_manifest.json file.
+#   mscs-versions-json              - Location of the version_manifest.json file.
+#   mscs-versions-duration          - Duration (in minutes) to keep the version_manifest.json file before updating.
+#   mscs-lockfile-duration          - Duration (in minutes) to keep lock files before removing.
+#   mscs-detailed-listing           - Properties to return for detailed listings.
+#   mscs-default-world              - Default world name.
+#   mscs-default-port               - Default Port.
+#   mscs-default-ip                 - Default IP address.
+#   mscs-default-version-type       - Default version type (release or snapshot).
+#   mscs-default-client-version     - Default version of the client software.
+#   mscs-default-client-jar         - Default .jar file for the client software.
+#   mscs-default-client-url         - Default download URL for the client software.
+#   mscs-default-client-location    - Default location of the client .jar file.
+#   mscs-default-server-version     - Default version of the server software.
+#   mscs-default-jvm-args           - Default arguments for the JVM.
+#   mscs-default-server-jar         - Default .jar file for the server software.
+#   mscs-default-server-url         - Default download URL for the server software.
+#   mscs-default-server-args        - Default arguments for a world server.
+#   mscs-default-initial-memory     - Default initial amount of memory for a world server.
+#   mscs-default-maximum-memory     - Default maximum amount of memory for a world server.
+#   mscs-default-server-location    - Default location of the server .jar file.
+#   mscs-default-server-command     - Default command to run for a world server.
+#   mscs-enable-restart-after-crash - Enable the option to restart worlds after crash detected (default enabled).
+#   mscs-backup-location            - Location to store backup files.
+#   mscs-backup-log                 - Location of the backup log file.
+#   mscs-backup-duration            - Length in days that backups survive.
+#   mscs-log-duration               - Length in days that logs survive.
+#   mscs-enable-mirror              - Enable the mirror option by default for worlds (default disabled).
+#   mscs-mirror-path                - Default path for the mirror files.
+#   mscs-overviewer-bin             - Location of Overviewer.
+#   mscs-overviewer-url             - URL for Overviewer.
+#   mscs-maps-location              - Location of Overviewer generated map files.
+#   mscs-maps-url                   - URL for accessing Overviewer generated maps.
+#
 #
 # The following variables may be used in some of the key values:
 #   $JAVA                - The Java virtual machine.
@@ -2234,6 +2371,7 @@ fi
 #   mscs-default-maximum-memory=2048M
 #   mscs-default-server-location=/opt/mscs/server
 #   mscs-default-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
+#   mscs-enable-restart-after-crash=0
 #   mscs-backup-location=/opt/mscs/backups
 #   mscs-backup-log=/opt/mscs/backups/backup.log
 #   mscs-backup-duration=15
@@ -2339,6 +2477,10 @@ VERSIONS_JSON=$(getDefaultsValue 'mscs-versions-json' $LOCATION'/version_manifes
 VERSIONS_DURATION=$(getDefaultsValue 'mscs-versions-duration' '30')
 # The duration (in minutes) to keep lock files before removing.
 LOCKFILE_DURATION=$(getDefaultsValue 'mscs-lockfile-duration' '1440')
+# Enable the option to restart the server after a crash is detected.
+# 0 - Restart after crash (default).
+# 1 - Do not restart after crash.
+ENABLE_RESTART_AFTER_CRASH=$(getDefaultsValue 'mscs-enable-restart-after-crash' '0')
 
 # Backup Configuration
 # ---------------------------------------------------------------------------
@@ -2417,7 +2559,7 @@ case "$COMMAND" in
       WORLDS=''
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
-          if serverRunning "$arg"; then
+          if [ $(serverRunning "$arg") -eq 0 ]; then
             printf "Unable to start the requested worlds: world '$arg' already running.\n"
             exit 1
           else
@@ -2437,7 +2579,7 @@ case "$COMMAND" in
     # Start each world requested, if not already running.
     printf "Starting Minecraft Server:"
     for WORLD in $WORLDS; do
-      if ! serverRunning $WORLD; then
+      if [ $(serverRunning "$WORLD") -eq 1 ]; then
         printf " $WORLD"
         start $WORLD
       fi
@@ -2449,7 +2591,7 @@ case "$COMMAND" in
     if [ "$#" -ge 1 ]; then
       for arg in "$@"; do
         if isWorldEnabled "$arg"; then
-          if ! serverRunning "$arg"; then
+          if [ $(serverRunning "$arg") -eq 1 ]; then
             printf "Unable to stop the requested worlds: world '$arg' already stopped.\n"
             exit 1
           else
@@ -2476,7 +2618,7 @@ case "$COMMAND" in
     printf "Stopping Minecraft Server:"
     for WORLD in $WORLDS; do
       # Try to stop the world cleanly.
-      if serverRunning $WORLD; then
+      if [ $(serverRunning "$WORLD") -eq 0 ]; then
         printf " $WORLD"
         if [ $(queryNumUsers $WORLD) -gt 0 ]; then
           sendCommand $WORLD "say The server admin has initiated a server shut down."
@@ -2528,7 +2670,7 @@ case "$COMMAND" in
     printf "Restarting Minecraft Server:"
     for WORLD in $WORLDS; do
       printf " $WORLD"
-      if serverRunning $WORLD; then
+      if [ $(serverRunning "$WORLD") -eq 0 ]; then
         if [ $(queryNumUsers $WORLD) -gt 0 ]; then
           sendCommand $WORLD "say The server admin has initiated a server restart."
           sendCommand $WORLD "say The server will restart in 1 minute..."
@@ -2600,7 +2742,7 @@ case "$COMMAND" in
       exit 1
     fi
     # Make sure the world is stopped.
-    if serverRunning "$1"; then
+    if [ $(serverRunning "$1") -eq 0 ]; then
       # If the world server has users logged in, announce that the world is
       # being modified.
       if [ $(queryNumUsers "$1") -gt 0 ]; then
@@ -2639,7 +2781,7 @@ case "$COMMAND" in
         exit 1
     else
       printf "Deleting Minecraft world: $1"
-      if serverRunning "$1"; then
+      if [ $(serverRunning "$1") -eq 0 ]; then
         # If the world server has users logged in, announce that the world is
         # being deleted.
         if [ $(queryNumUsers "$1") -gt 0 ]; then
@@ -2682,7 +2824,7 @@ case "$COMMAND" in
     printf "Disabling Minecraft world:"
     for WORLD in $WORLDS; do
       printf " $WORLD"
-      if serverRunning "$WORLD"; then
+      if [ $(serverRunning "$WORLD") -eq 0 ]; then
         # If the world server has users logged in, announce that the world is
         # being disabled.
         if [ $(queryNumUsers "$WORLD") -gt 0 ]; then
@@ -2747,14 +2889,14 @@ case "$COMMAND" in
         ;;
       running)
         for WORLD in $(getEnabledWorlds); do
-          if serverRunning $WORLD; then
+          if [ $(serverRunning "$WORLD") -eq 0 ]; then
             WORLDS="$WORLDS $WORLD"
           fi
         done
         ;;
       stopped)
         for WORLD in $(getEnabledWorlds); do
-          if ! serverRunning $WORLD; then
+          if [ $(serverRunning "$WORLD") -eq 1 ]; then
             WORLDS="$WORLDS $WORLD"
           fi
         done
@@ -2862,7 +3004,7 @@ case "$COMMAND" in
     # Synchronize the images for each world.
     printf "Synchronizing Minecraft Server:"
     for WORLD in $WORLDS; do
-      if serverRunning $WORLD; then
+      if [ $(serverRunning "$WORLD") -eq 0 ]; then
         printf " $WORLD"
         sendCommand $WORLD "save-all"
         if [ $ENABLE_MIRROR -eq 1 ]; then
@@ -2886,7 +3028,7 @@ case "$COMMAND" in
       # Broadcast the message to all of the enabled worlds.
       printf "Broadcasting command to world:"
       for WORLD in $WORLDS; do
-        if serverRunning $WORLD; then
+        if [ $(serverRunning "$WORLD") -eq 0 ]; then
           printf " $WORLD"
           sendCommand $WORLD "$*"
         fi
@@ -2996,7 +3138,7 @@ case "$COMMAND" in
       printf " $WORLD"
       # Create a lock file so that we don't create duplicate processes.
       if $(createLockFile $WORLD "backup"); then
-        if serverRunning $WORLD; then
+        if [ $(serverRunning "$WORLD") -eq 0 ]; then
           sendCommand $WORLD "say Backing up the world."
           sendCommand $WORLD "save-all"
           sendCommand $WORLD "save-off"
@@ -3038,7 +3180,7 @@ case "$COMMAND" in
       printf "World '$1' not recognized.\n"
       printf "  Usage:  $PROG $COMMAND <world> <datetime>\n"
       exit 1
-    elif serverRunning "$1"; then
+    elif [ $(serverRunning "$1") -eq 0 ]; then
       printf "World '$1' is running. Stop it first\n"
       printf "  $PROG stop $1\n"
       exit 1
@@ -3083,7 +3225,7 @@ case "$COMMAND" in
     RUNNING=
     printf "Stopping Minecraft Server:"
     for WORLD in $WORLDS; do
-      if serverRunning $WORLD; then
+      if [ $(serverRunning "$WORLD") -eq 0 ]; then
         RUNNING="$RUNNING $WORLD"
         printf " $WORLD"
         if [ $(queryNumUsers $WORLD) -gt 0 ]; then


### PR DESCRIPTION
## Automatic crash detection and restarts

```
; Enable the option to restart the server after a crash is detected.
; 0 - Restart after crash (default).
; 1 - Do not restart after crash.
# mscs-enable-restart-after-crash=0
```

This is a preliminary PR for #225 that enables the option to restart worlds after a crash is detected using the `mscs-enable-restart-after-crash` flag (via `mscs.defaults`). I set the default to be 0 (`true`), but we can change the default to be 1 (`false`) if you think that's better. Additionally, we could add the functionality for it to be available on a per world basis via `mscs.properties` if you think that's a good idea as well.


How it works:

1. When a world is started, the `startServerMonitor()` function is called. This checks if the `mscs-enable-restart-after-crash` flag is enabled. If so, it checks if there is another instance of the server monitor already running (which would occur if the server was restarted after a crash). To do this check, it uses `flock`. I tried for several hours to use the `createLockFile()` function, but it didn't work for me for whatever reason--not sure if it was because I was doing something wrong or if it was just an issue with the function itself. @sandain  If you're able to get the `createLockFile()` function working instead of using flock, that'd be good so we don't have to use `flock` as a dependency. 

2. If the monitor is not running, the `startServerMonitor()` function essentially calls the `nohup` command on the `serverMonitor()` function and runs it in the background, so you can close the terminal and the crash monitor will keep running. `nohup` doesn't allow you to pass functions, but I managed to recreate the functionality through some research. The PID of the monitor is stored in `$WORLD_DIR/monitor.pid`.

3. The `serverMonitor()` function is essentially a loop that detects if the server has crashed by a combination of the a) the existence of the `$WORLD.pid` file and b) whether the server is running via the `serverRunning()` function. If the PID file exists but the server isn't running, then this means the server probably crashed (since MSCS hasn't removed the PID file). 
Additionally, I had to modify the serverRunning() function to use `echo` instead of `return` to return values so I could call the function in the test condition of the `until` loop and check the return value using `$()` (I didn't think I could do this the way the function was, but maybe I'm wrong). I subsequently modified all of the references in the script to call serverRunning using `$()`.
 There is also a log for the monitor written to `$WORLD_DIR/logs/mscs.monitor.log`. This log is deleted after `$LOG_DURATION` to make sure it doesn't get too large. This check occurs in the `startServerMonitor()` function. There is also a log created called `last-start-status.log` that stores a message to be displayed later in the `mscs status` command.

4. When the `mscs stop` command is called, it sends a request to kill the server monitor using the `stopServerMonitor()` function. At this point the monitor should be killed.

When a user runs the `mscs status` for the first time after a server has crashed, they will see a notice that the world has crashed:
```
$ mscs status
Minecraft Server Status:
  alex: running version 1.16.2 (0 of 20 users online).
    Port: 25567.
    Memory used: 1.04GB (2GB allocated).
    Server PID: 3351.
    Crash Monitor PID: 19569
    alex automatically restarted from a crash (or in-game stop command)
    on 2020-08-15_22-49-13. See
    /opt/mscs/worlds/alex/logs/mscs.monitor.log and
    /opt/mscs/worlds/alex/crash_reports/ and
    /opt/mscs/worlds/alex/logs/ for more information.
```
This notice goes away after the first time. The code behind this is simply a check if whether or not the `last-start-status.log` file exists and is not empty. If this is true, the message is displayed and the file is deleted afterwards (so the message is only displayed once).

P.S.: I tested crashes on the code by doing the `/stop` command in-game, I believe it should replicate what happens with an actual crash.

Please let me know of any questions or recommendations you have or bugs you find. Thanks!!

**Summary of TODO:**
- Remove flock dependency
- Test more
- Question: add functionality to enable it on a per-world basis?
- Question: make the default setting true or false?