### PR TITLE
Add automatic crash detection and restarts

### DIFF
--- a/msctl
+++ b/msctl
@@ -1323,7 +1323,7 @@ stopServerMonitor() {
 # @param 1 The world server to monitor.
 # ---------------------------------------------------------------------------
 serverMonitor() {
-  local WORLD_DIR MONITOR_LOG SERVER_LOG LAST_START_STATUS_LOG MONITOR_PID GREP_STOP
+  local WORLD_DIR MONITOR_LOG SERVER_LOG LAST_START_STATUS_LOG MONITOR_PID
   WORLD_DIR="$WORLDS_LOCATION/$1"
   MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
   SERVER_LOG="$WORLD_DIR/logs/latest.log"

--- a/msctl
+++ b/msctl
@@ -47,6 +47,7 @@ WGET=$(which wget)
 RDIFF_BACKUP=$(which rdiff-backup)
 RSYNC=$(which rsync)
 SOCAT=$(which socat)
+FLOCK=$(which flock)
 
 # Script Usage
 # ---------------------------------------------------------------------------
@@ -1310,7 +1311,7 @@ stopServerMonitor() {
       printf "[$(timestamp)] [ERROR]: Unable to kill monitor process.\n" >> "$MONITOR_LOG"
       exit 1
     else 
-      printf "[$(timestamp)] [INFO]: Server monitor process killed sucessfully.\n" >> "$MONITOR_LOG"
+      printf "[$(timestamp)] [INFO]: Server monitor process killed successfully.\n" >> "$MONITOR_LOG"
       # Remove the monitor PID file. 
       rm -f "$WORLD_DIR/monitor.pid"
     fi
@@ -2198,7 +2199,7 @@ worldStatusJSON() {
 # ---------------------------------------------------------------------------
 
 # Make sure that Java, Perl, libjson-perl, libwww-perl, Python, Wget,
-# Rdiff-backup, Rsync, and Socat are installed.
+# Rdiff-backup, Rsync, Socat and flock are installed.
 # ---------------------------------------------------------------------------
 if [ ! -e "$JAVA" ]; then
   echo "ERROR: Java not found!"
@@ -2261,6 +2262,12 @@ if [ ! -e "$SOCAT" ]; then
   echo "ERROR: socat not found!"
   echo "Try installing this with:"
   echo "sudo apt-get install socat"
+  exit 1
+fi
+if [ ! -e "$FLOCK" ]; then
+  echo "ERROR: flock not found!"
+  echo "Try installing this with:"
+  echo "sudo apt-get install flock"
   exit 1
 fi
 

--- a/msctl
+++ b/msctl
@@ -2267,7 +2267,7 @@ fi
 if [ ! -e "$FLOCK" ]; then
   echo "ERROR: flock not found!"
   echo "Try installing this with:"
-  echo "sudo apt-get install flock"
+  echo "sudo apt-get install util-linux"
   exit 1
 fi
 

--- a/msctl
+++ b/msctl
@@ -1300,7 +1300,7 @@ stopServerMonitor() {
   MONITOR_LOCK_FILE="$WORLD_DIR/monitor.lock"
   # Check if server monitor instance currently running.
   (
-  flock -n 9
+  $FLOCK -n 9
   ACQUIRED_LOCK=$?
   if [ "$ACQUIRED_LOCK" -eq 1 ]; then # Server monitor is running.
     printf "[$(timestamp)] [INFO]: Stop command received for server monitor. Attempting to kill server monitor...\n" >> "$MONITOR_LOG"

--- a/msctl
+++ b/msctl
@@ -1376,7 +1376,7 @@ startServerMonitor() {
   if [ "$RESTART_AFTER_CRASH" = "true" ]; then
     # Verify that there is no monitor instance currently running.
     (
-    flock -n 9
+    $FLOCK -n 9
     ACQUIRED_LOCK=$?
     if [ "$ACQUIRED_LOCK" -eq 0 ]; then # Server monitor doesn't exist.
       # Delete old log file greater than $LOG_DURATION, if it exists.

--- a/msctl
+++ b/msctl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ---------------------------------------------------------------------------
-# Copyright (c) 2011-2016, Jason M. Wood <sandain@hotmail.com>
+# Copyright (c) 2011-2021, Jason M. Wood <sandain@hotmail.com>
 #
 # All rights reserved.
 #
@@ -275,6 +275,9 @@ mscs_defaults() {
 ; selected. The \$SERVER_ARGS variable provides access to the server arguments
 ; for the world server selected.
 # mscs-default-server-command=\$JAVA -Xms\$INITIAL_MEMORY -Xmx\$MAXIMUM_MEMORY \$JVM_ARGS -jar \$SERVER_LOCATION/\$SERVER_JAR \$SERVER_ARGS
+
+; Default behavior if to restart the server after crash is detected (default disabled).
+# mscs-default-restart-after-crash=false
 
 ; Location to store backup files.
 # mscs-backup-location=/opt/mscs/backups
@@ -1275,6 +1278,123 @@ serverConsole() {
 }
 
 # ---------------------------------------------------------------------------
+# Retrieve the timestamp.
+#
+# @return The current date and time.
+# ---------------------------------------------------------------------------
+timestamp() {
+  date +"%Y-%m-%d_%H-%M-%S"
+}
+
+# ---------------------------------------------------------------------------
+# Stop the server monitor.
+#
+# @param 1 The world server to stop.
+# ---------------------------------------------------------------------------
+stopServerMonitor() {
+  local WORLD_DIR MONITOR_LOG MONITOR_PID MONITOR_LOCK_FILE ACQUIRED_LOCK
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  MONITOR_LOCK_FILE="$WORLD_DIR/monitor.lock"
+  # Check if server monitor instance currently running.
+  (
+  flock -n 9
+  ACQUIRED_LOCK=$?
+  if [ "$ACQUIRED_LOCK" -eq 1 ]; then # Server monitor is running.
+    printf "[$(timestamp)] [INFO]: Stop command received for server monitor. Attempting to kill server monitor...\n" >> "$MONITOR_LOG"
+    # Kill the server monitor.
+    kill -9 $(cat $MONITOR_PID)
+    # Verify it was actually killed.
+    if [ $? -eq 1 ]; then
+      printf "[$(timestamp)] [ERROR]: Unable to kill monitor process.\n" >> "$MONITOR_LOG"
+      exit 1
+    else 
+      printf "[$(timestamp)] [INFO]: Server monitor process killed sucessfully.\n" >> "$MONITOR_LOG"
+      # Remove the monitor PID file. 
+      rm -f "$WORLD_DIR/monitor.pid"
+    fi
+  fi
+  ) 9>"$MONITOR_LOCK_FILE"
+}
+# ---------------------------------------------------------------------------
+# Run the server monitor.
+#
+# @param 1 The world server to monitor.
+# ---------------------------------------------------------------------------
+serverMonitor() {
+  local WORLD_DIR MONITOR_LOG SERVER_LOG LAST_START_STATUS_LOG MONITOR_PID GREP_STOP
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  SERVER_LOG="$WORLD_DIR/logs/latest.log"
+  LAST_START_STATUS_LOG="$WORLD_DIR/logs/last-start-status.log"
+  MONITOR_PID=$(cat "$WORLD_DIR/monitor.pid")
+  touch $LAST_START_STATUS_LOG
+
+  printf "[$(timestamp)] [INFO]: Server monitoring started for $1. Server PID: $(getJavaPID $1). Monitor PID: $MONITOR_PID.\n"
+  # Run monitor until the server is stopped and the PID file is removed (i.e. clean shutdown).
+  until  ! serverRunning $1 && [ ! -f "$WORLDS_LOCATION/$1.pid" ]; do
+    # If server isn't running and server PID file exists, server crashed.
+    if  ! serverRunning $1 && [ -f "$WORLDS_LOCATION/$1.pid" ]; then
+      printf "[$(timestamp)] [WARN]: Server crash detected. Attempting to restart $1...\n"
+      start $1
+      # Verify that the server restarted successfully. 
+      if [ $? -eq 0 ]; then
+        printf "[$(timestamp)] [INFO]: Server monitoring resumed for $1. Server PID: $(getJavaPID $1). Monitor PID: $MONITOR_PID.\n"
+        printf "    $1 automatically restarted from a crash (or in-game stop command)\n" > "$LAST_START_STATUS_LOG"
+        printf "    on $(timestamp). See\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/logs/mscs.monitor.log and\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/crash_reports/ and\n" >> "$LAST_START_STATUS_LOG"
+        printf "    $WORLD_DIR/logs/ for more information.\n" >> "$LAST_START_STATUS_LOG"
+      else
+        printf "[$(timestamp)] [ERROR]: Failed to restart $1.\n" 
+        stopServerMonitor $1
+      fi
+    # If server is running and server PID file doesn't exist, error occurred.
+    elif serverRunning $1 && [ ! -f "$WORLDS_LOCATION/$1.pid" ]; then
+      printf "[$(timestamp)] [ERROR]: PID file doesn't exist.\n"
+      stopServerMonitor $1
+    fi 
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Start the server monitor.
+#
+# @param 1 The world server to monitor.
+# ---------------------------------------------------------------------------
+startServerMonitor() {
+  local WORLD_DIR MONITOR_LOG MONITOR_PID MONITOR_LOCK_FILE ACQUIRED_LOCK
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_LOG="$WORLD_DIR/logs/mscs.monitor.log"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  MONITOR_LOCK_FILE="$WORLD_DIR/monitor.lock"
+  RESTART_AFTER_CRASH=$(getMSCSValue "$1" "mscs-restart-after-crash" "$DEFAULT_RESTART_AFTER_CRASH")
+
+  # Verify option is enabled.
+  if [ "$RESTART_AFTER_CRASH" = "true" ]; then
+    # Verify that there is no monitor instance currently running.
+    (
+    flock -n 9
+    ACQUIRED_LOCK=$?
+    if [ "$ACQUIRED_LOCK" -eq 0 ]; then # Server monitor doesn't exist.
+      # Delete old log file greater than $LOG_DURATION, if it exists.
+      if [ -f "$MONITOR_LOG" ]; then
+        if [ "$LOG_DURATION" -gt 0 ]; then
+          find "$MONITOR_LOG" -type f -mtime +"$LOG_DURATION" -delete
+        fi
+      fi
+      # Run the server monitor.
+      # Nohup does not allow you to pass functions. However, the code below mimics nohup behavior by doing the following:
+        # Start subshell, ignore HUP signal, redirect stdin to /dev/null, redirect stdout and stderr to log file, run in background.
+      # Also store the PID of this process for later use.
+      ( trap "true" HUP ; pid=$(exec sh -c 'echo "$PPID"'); echo $pid > "$MONITOR_PID"; serverMonitor $1 ) </dev/null 2>&1 1>>"$MONITOR_LOG" & 
+    fi
+    ) 9>"$MONITOR_LOCK_FILE"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Start the world server.  Generate the appropriate environment for the
 # server if it doesn't already exist.
 #
@@ -1378,6 +1498,8 @@ start() {
   fi
   # Create a PID file for the world server.
   echo $PID >"$WORLDS_LOCATION/$1.pid"
+  # Start the server crash monitor, if enabled.
+  startServerMonitor $1
 }
 
 # ---------------------------------------------------------------------------
@@ -1386,6 +1508,8 @@ start() {
 # @param 1 The world server to stop.
 # ---------------------------------------------------------------------------
 stop() {
+  # Stop the server monitor if it is running.
+  stopServerMonitor $1
   # Tell the server to stop.
   sendCommand $1 "stop"
   sendCommand $1 "end"
@@ -1414,6 +1538,8 @@ stop() {
 # ---------------------------------------------------------------------------
 forceStop() {
   local WAIT
+  # Stop the server monitor if it is running.
+  stopServerMonitor $1
   # Try to stop the server cleanly first.
   sendCommand $1 "stop"
   sendCommand $1 "end"
@@ -1828,9 +1954,9 @@ querySendPacket() {
       printf "%s\n", join "\t", unpack ($format, $packed);
     ' -- -response="$RESPONSE" -format="$4"
 
-  # If the response is empty and the query.in and query.out files have NOT been created,
+  # If the response is empty and both the query.in and query.out files have NOT been created,
   # the world is still starting up and the status query will return as such.
-  # See lines 1985-1987.
+  # See the worldStatus function.
 
   # If the response is empty and the query.in and query.out files HAVE been created,
   # something went wrong. We try restarting the query handler again.
@@ -1994,8 +2120,11 @@ queryNumUsers() {
 # @param 1 The world server of interest.
 # ---------------------------------------------------------------------------
 worldStatus() {
-  local STATUS NUM MAX PLAYERS COUNTER VERSION
-  if serverRunning $1; then
+  local WORLD_DIR LAST_START_STATUS_LOG MONITOR_PID STATUS NUM MAX PLAYERS COUNTER VERSION 
+  WORLD_DIR="$WORLDS_LOCATION/$1"
+  MONITOR_PID="$WORLD_DIR/monitor.pid"
+  LAST_START_STATUS_LOG="$WORLD_DIR/logs/last-start-status.log"
+  if  serverRunning $1; then
     STATUS=$(queryDetailedStatus $1)
     if [ -n "$STATUS" ]; then
       NUM=$(printf "%s" "$STATUS" | cut -f 19)
@@ -2020,10 +2149,21 @@ worldStatus() {
       printf "world starting up.\n"
     else
       printf "running.\n"
-    fi
+    fi 
     printf "    Memory used: $(getJavaMemory "$1" | awk '{$1=int(100 * $1/1024/1024)/100"GB";}{ print;}')"
     printf " ($(getMSCSValue "$1" "mscs-maximum-memory" "$DEFAULT_MAXIMUM_MEMORY" | rev | cut -c 2- | rev | awk '{$1=int($1/1024)"GB";}{ print;}') allocated).\n"
-    printf "    Process ID: %d.\n" $(getJavaPID "$1")
+    printf "    Server PID: %d.\n" $(getJavaPID "$1")
+    # Display crash monitor PID if it's running (i.e. monitor.pid file exists and not empty).
+    if [ -f "$MONITOR_PID" ] && [ -s "$MONITOR_PID" ]; then
+      printf "    Crash Monitor PID: $(cat $MONITOR_PID)\n"
+    fi
+    # If the last-status log exists and not empty, then last restart was from a crash.
+    # Display notice once.
+    if [ -f "$LAST_START_STATUS_LOG" ] && [ -s "$LAST_START_STATUS_LOG" ]; then
+      printf "$(cat $LAST_START_STATUS_LOG)\n"
+      # Remove it so user doesn't see it next time they run the status command.
+      rm -f $LAST_START_STATUS_LOG
+    fi
   elif [ "$(getMSCSValue $1 'mscs-enabled')" = "false" ]; then
     printf "disabled.\n"
   else
@@ -2186,46 +2326,50 @@ fi
 if [ ! -s "$MSCS_DEFAULTS" ]; then
   mscs_defaults >$MSCS_DEFAULTS
 fi
+
 # Default values in the script can be overridden by adding certain key/value
 # pairs to one of the mscs.defaults files mentioned above. Default values in
 # the script will be used unless overridden in one these files.
 #
 # The following keys are available:
-#   mscs-location                - Location of the mscs files.
-#   mscs-worlds-location         - Location of world files.
-#   mscs-versions-url            - URL to download the version_manifest.json file.
-#   mscs-versions-json           - Location of the version_manifest.json file.
-#   mscs-versions-duration       - Duration (in minutes) to keep the version_manifest.json file before updating.
-#   mscs-lockfile-duration       - Duration (in minutes) to keep lock files before removing.
-#   mscs-default-world           - Default world name.
-#   mscs-default-port            - Default Port.
-#   mscs-default-ip              - Default IP address.
-#   mscs-default-version-type    - Default version type (release or snapshot).
-#   mscs-default-client-version  - Default version of the client software.
-#   mscs-default-client-jar      - Default .jar file for the client software.
-#   mscs-default-client-url      - Default download URL for the client software.
-#   mscs-default-client-location - Default location of the client .jar file.
-#   mscs-default-server-version  - Default version of the server software.
-#   mscs-default-jvm-args        - Default arguments for the JVM.
-#   mscs-default-server-jar      - Default .jar file for the server software.
-#   mscs-default-server-url      - Default download URL for the server software.
-#   mscs-default-server-args     - Default arguments for a world server.
-#   mscs-default-initial-memory  - Default initial amount of memory for a world server.
-#   mscs-default-maximum-memory  - Default maximum amount of memory for a world server.
-#   mscs-default-server-location - Default location of the server .jar file.
-#   mscs-default-server-command  - Default command to run for a world server.
-#   mscs-backup-location         - Location to store backup files.
-#   mscs-backup-log              - Lcation of the backup log file.
-#   mscs-backup-excluded-files   - Comma separated list of files and directories excluded from backups.
-#   mscs-backup-duration         - Length in days that backups survive.
-#   mscs-log-duration            - Length in days that logs survive.
-#   mscs-detailed-listing        - Properties to return for detailed listings.
-#   mscs-enable-mirror           - Enable the mirror option by default for worlds (default disabled).
-#   mscs-mirror-path             - Default path for the mirror files.
-#   mscs-overviewer-bin          - Location of Overviewer.
-#   mscs-overviewer-url          - URL for Overviewer.
-#   mscs-maps-location           - Location of Overviewer generated map files.
-#   mscs-maps-url                - URL for accessing Overviewer generated maps.
+#   mscs-location                    - Location of the mscs files.
+#   mscs-worlds-location             - Location of world files.
+#   mscs-versions-url                - URL to download the version_manifest.json file.
+#   mscs-versions-json               - Location of the version_manifest.json file.
+#   mscs-versions-duration           - Duration (in minutes) to keep the version_manifest.json file before updating.
+#   mscs-lockfile-duration           - Duration (in minutes) to keep lock files before removing.
+#   mscs-detailed-listing            - Properties to return for detailed listings.
+#   mscs-default-world               - Default world name.
+#   mscs-default-port                - Default Port.
+#   mscs-default-ip                  - Default IP address.
+#   mscs-default-version-type        - Default version type (release or snapshot).
+#   mscs-default-client-version      - Default version of the client software.
+#   mscs-default-client-jar          - Default .jar file for the client software.
+#   mscs-default-client-url          - Default download URL for the client software.
+#   mscs-default-client-location     - Default location of the client .jar file.
+#   mscs-default-server-version      - Default version of the server software.
+#   mscs-default-jvm-args            - Default arguments for the JVM.
+#   mscs-default-server-jar          - Default .jar file for the server software.
+#   mscs-default-server-url          - Default download URL for the server software.
+#   mscs-default-server-args         - Default arguments for a world server.
+#   mscs-default-initial-memory      - Default initial amount of memory for a world server.
+#   mscs-default-maximum-memory      - Default maximum amount of memory for a world server.
+#   mscs-default-server-location     - Default location of the server .jar file.
+#   mscs-default-server-command      - Default command to run for a world server.
+#   mscs-default-server-command      - Default command to run for a world server.
+#   mscs-default-restart-after-crash - Default behavior if to restart the server after crash is detected (default disabled).
+#   mscs-backup-location             - Location to store backup files.
+#   mscs-backup-excluded-files       - Comma separated list of files and directories excluded from backups.
+#   mscs-backup-log                  - Location of the backup log file.
+#   mscs-backup-duration             - Length in days that backups survive.
+#   mscs-log-duration                - Length in days that logs survive.
+#   mscs-enable-mirror               - Enable the mirror option by default for worlds (default disabled).
+#   mscs-mirror-path                 - Default path for the mirror files.
+#   mscs-overviewer-bin              - Location of Overviewer.
+#   mscs-overviewer-url              - URL for Overviewer.
+#   mscs-maps-location               - Location of Overviewer generated map files.
+#   mscs-maps-url                    - URL for accessing Overviewer generated maps.
+#
 #
 # The following variables may be used in some of the key values:
 #   $JAVA                - The Java virtual machine.
@@ -2264,6 +2408,7 @@ fi
 #   mscs-default-maximum-memory=2048M
 #   mscs-default-server-location=/opt/mscs/server
 #   mscs-default-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY $JVM_ARGS -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
+#   mscs-default-restart-after-crash=false
 #   mscs-backup-location=/opt/mscs/backups
 #   mscs-backup-log=/opt/mscs/backups/backup.log
 #   mscs-backup-excluded_files=
@@ -2311,25 +2456,27 @@ DEFAULT_INITIAL_MEMORY=$(getDefaultsValue 'mscs-default-initial-memory' '128M')
 DEFAULT_MAXIMUM_MEMORY=$(getDefaultsValue 'mscs-default-maximum-memory' '2048M')
 DEFAULT_SERVER_LOCATION=$(getDefaultsValue 'mscs-default-server-location' $LOCATION'/server')
 DEFAULT_SERVER_COMMAND=$(getDefaultsValue 'mscs-default-server-command' '$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY $JVM_ARGS -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS')
+DEFAULT_RESTART_AFTER_CRASH=$(getDefaultsValue 'mscs-default-restart-after-crash' 'false')
 # Each world server can override the default values in a similar manner by
 # adding certain key/value pairs to the world's mscs.properties file.
 #
 # The following keys are available:
-#   mscs-enabled         - Enable or disable the world server.
-#   mscs-version-type    - Assign the version type (release or snapshot).
-#   mscs-client-version  - Assign the version of the client software.
-#   mscs-client-jar      - Assign the .jar file for the client software.
-#   mscs-client-url      - Assign the download URL for the client software.
-#   mscs-client-location - Assign the location of the client .jar file.
-#   mscs-server-version  - Assign the version of the server software.
-#   mscs-jvm-args        - Assign the arguments to the JVM.
-#   mscs-server-jar      - Assign the .jar file for the server software.
-#   mscs-server-url      - Assign the download URL for the server software.
-#   mscs-server-args     - Assign the arguments to the server.
-#   mscs-initial-memory  - Assign the initial amount of memory for the server.
-#   mscs-maximum-memory  - Assign the maximum amount of memory for the server.
-#   mscs-server-location - Assign the location of the server .jar file.
-#   mscs-server-command  - Assign the command to run for the server.
+#   mscs-enabled             - Enable or disable the world server.
+#   mscs-version-type        - Assign the version type (release or snapshot).
+#   mscs-client-version      - Assign the version of the client software.
+#   mscs-client-jar          - Assign the .jar file for the client software.
+#   mscs-client-url          - Assign the download URL for the client software.
+#   mscs-client-location     - Assign the location of the client .jar file.
+#   mscs-server-version      - Assign the version of the server software.
+#   mscs-jvm-args            - Assign the arguments to the JVM.
+#   mscs-server-jar          - Assign the .jar file for the server software.
+#   mscs-server-url          - Assign the download URL for the server software.
+#   mscs-server-args         - Assign the arguments to the server.
+#   mscs-initial-memory      - Assign the initial amount of memory for the server.
+#   mscs-maximum-memory      - Assign the maximum amount of memory for the server.
+#   mscs-server-location     - Assign the location of the server .jar file.
+#   mscs-server-command      - Assign the command to run for the server.
+#   mscs-restart-after-crash - Restart the server after a crash (default disabled).
 #
 # Like above, the following variables may be used in some of the key values:
 #   $JAVA                - The Java virtual machine.
@@ -2359,6 +2506,7 @@ DEFAULT_SERVER_COMMAND=$(getDefaultsValue 'mscs-default-server-command' '$JAVA -
 #   mscs-maximum-memory=2048M
 #   mscs-server-location=/opt/mscs/server
 #   mscs-server-command=$JAVA -Xms$INITIAL_MEMORY -Xmx$MAXIMUM_MEMORY $JVM_ARGS -jar $SERVER_LOCATION/$SERVER_JAR $SERVER_ARGS
+#   mscs-restart-after-crash=false
 
 # World (Server Instance) Configuration
 # ---------------------------------------------------------------------------
@@ -2370,6 +2518,8 @@ VERSIONS_JSON=$(getDefaultsValue 'mscs-versions-json' $LOCATION'/version_manifes
 VERSIONS_DURATION=$(getDefaultsValue 'mscs-versions-duration' '30')
 # The duration (in minutes) to keep lock files before removing.
 LOCKFILE_DURATION=$(getDefaultsValue 'mscs-lockfile-duration' '1440')
+# Enable the option to restart the server after a crash is detected (default disabled).
+RESTART_AFTER_CRASH=$(getDefaultsValue 'mscs-restart-after-crash' 'false')
 
 # Backup Configuration
 # ---------------------------------------------------------------------------

--- a/msctl
+++ b/msctl
@@ -2338,7 +2338,6 @@ fi
 #   mscs-versions-json               - Location of the version_manifest.json file.
 #   mscs-versions-duration           - Duration (in minutes) to keep the version_manifest.json file before updating.
 #   mscs-lockfile-duration           - Duration (in minutes) to keep lock files before removing.
-#   mscs-detailed-listing            - Properties to return for detailed listings.
 #   mscs-default-world               - Default world name.
 #   mscs-default-port                - Default Port.
 #   mscs-default-ip                  - Default IP address.
@@ -2356,20 +2355,19 @@ fi
 #   mscs-default-maximum-memory      - Default maximum amount of memory for a world server.
 #   mscs-default-server-location     - Default location of the server .jar file.
 #   mscs-default-server-command      - Default command to run for a world server.
-#   mscs-default-server-command      - Default command to run for a world server.
 #   mscs-default-restart-after-crash - Default behavior if to restart the server after crash is detected (default disabled).
 #   mscs-backup-location             - Location to store backup files.
-#   mscs-backup-excluded-files       - Comma separated list of files and directories excluded from backups.
 #   mscs-backup-log                  - Location of the backup log file.
+#   mscs-backup-excluded-files       - Comma separated list of files and directories excluded from backups.
 #   mscs-backup-duration             - Length in days that backups survive.
 #   mscs-log-duration                - Length in days that logs survive.
+#   mscs-detailed-listing            - Properties to return for detailed listings.
 #   mscs-enable-mirror               - Enable the mirror option by default for worlds (default disabled).
 #   mscs-mirror-path                 - Default path for the mirror files.
 #   mscs-overviewer-bin              - Location of Overviewer.
 #   mscs-overviewer-url              - URL for Overviewer.
 #   mscs-maps-location               - Location of Overviewer generated map files.
 #   mscs-maps-url                    - URL for accessing Overviewer generated maps.
-#
 #
 # The following variables may be used in some of the key values:
 #   $JAVA                - The Java virtual machine.


### PR DESCRIPTION
Hi,

This is an updated PR from #257 : New changes:

- Updated the code to reflect the most recent codebase
- Changed the default setting to now being disabled
- Changed the name of the flag (from `mscs-enable-restart-after-crash` to `mscs-restart-after-crash`) for brevity
- Added the ability to set it on a per world basis (`mscs-default-restart-after-crash` and `mscs-restart-after-crash`)
- Changed the flags from `0/1` to `false/true` for clarity's sake
- Removed the old changes I made (in the `if` statements when trying to test if the server was running) that made the code less readable, and reverted it back to how the old way was done
- Updated the copyright year ;)

I still need to figure out if there's a way to check if there's a server monitor process running without using flock (which the code uses right now). As I mentioned in the last PR, I tried using the `createLockFile()` function that's in the script but it didn't work for me for some reason.

Probably should also test it a bit more. It does seem to be working as intended on my computer, though!

Thanks