### PR TITLE
Dynamic Systemd Units using Service Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MSCTL := /usr/local/bin/msctl
 MSCS := /usr/local/bin/mscs
 MSCS_INIT_D := /etc/init.d/mscs
 MSCS_SERVICE := /etc/systemd/system/mscs.service
+MSCS_SERVICE_TEMPLATE := /etc/systemd/system/mscs@.service
 MSCS_COMPLETION := /etc/bash_completion.d/mscs
 
 UPDATE_D := $(wildcard update.d/*)
@@ -28,6 +29,7 @@ update:
 	install -m 0644 mscs.completion $(MSCS_COMPLETION)
 	if which systemctl; then \
 		install -m 0644 mscs.service $(MSCS_SERVICE); \
+		install -m 0644 mscs@.service $(MSCS_SERVICE_TEMPLATE); \
 	fi
 	@for script in $(UPDATE_D); do \
 		sh $$script; \
@@ -36,7 +38,7 @@ update:
 clean:
 	if which systemctl; then \
 		systemctl -f disable mscs.service; \
-		rm -f $(MSCS_SERVICE); \
+		rm -f $(MSCS_SERVICE) $(MSCS_SERVICE_TEMPLATE); \
 	else \
 		update-rc.d mscs remove; \
 		rm -f $(MSCS_INIT_D); \

--- a/mscs@.service
+++ b/mscs@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Minecraft Server Control Script for server %i
+Documentation=https://github.com/MinecraftServerControl/mscs
+Requires=network.target
+After=network.target
+
+[Service]
+User=minecraft
+Group=minecraft
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/local/bin/mscs start %i
+ExecStop=/usr/local/bin/mscs stop %i
+ExecReload=/usr/local/bin/mscs restart %i
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi, big fan of MSCS but found that using the default `mscs.service` follows a "start all servers, or nothing" approach, so using Systemd's support for template units I added a template unit for MSCS that allows server admins to make individual service units for each server via `systemctl`.

With this PR, admins can disable the default `mscs.service` and make/delete units for individual minecraft servers with the following command:
`sudo systemctl [enable|disable] mscs@[server name]`

Or stop/start/restart one, or more servers if they want, using `systemctl`:
`sudo systemctl [start/restart/stop] mscs@[server 1 name] [mscs@[server 2 name]] ...`

I've tested the install and usage on my own minecraft servers and it seems to work without any issues.