### PR TITLE
Updated Makefile with a safety check for user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,12 @@ install: adduser update
 	fi
 	
 adduser:
-	useradd --system --user-group --create-home -K UMASK=0022 --home $(MSCS_HOME) $(MSCS_USER)
+        # safety check to see if user exists before trying to create it 
+	if id $(MSCS_USER); then \
+                echo "Minecraft user $(MSCS_USER) exists so not creating it"; \
+        else \
+                useradd --system --user-group --create-home -K UMASK=0022 --home $(MSCS_HOME) $(MSCS_USER); \
+        fi
 
 update:
 	install -m 0755 msctl $(MSCTL)


### PR DESCRIPTION
Added a safety check to see if the user exists when running make install. It was dying on me because the user already existed. Now if the user exists, it reports back the user exists and skips it.