### PR TITLE
Adding hook scritps to start, stop and force-stop. The scripts are ex…

### DIFF
--- a/msctl
+++ b/msctl
@@ -1453,6 +1453,17 @@ startServerMonitor() {
 start() {
   local EULA PID SERVER_COMMAND WORLD_DIR
   WORLD_DIR="$WORLDS_LOCATION/$1"
+
+  # Pre-start Hook script execution
+  PRE_START_HOOK="$WORLD_DIR/hooks/pre-start.sh"
+  if [ -x "$PRE_START_HOOK" ]; then
+    printf "Executing pre-start hook script for world %s...\n" "$1"
+    "$PRE_START_HOOK"
+    if [ $? -ne 0 ]; then
+      printf "Warning: pre-start hook script for world %s exited with a non-zero status.\n" "$1"
+    fi
+  fi
+
   # Make sure that the server software exists.
   updateServerSoftware "$1"
   # Make sure that the world's directory exists.
@@ -1566,6 +1577,16 @@ start() {
 # @param 1 The world server to stop.
 # ---------------------------------------------------------------------------
 stop() {
+  # Pre-stop Hook script execution
+  PRE_STOP_HOOK="$WORLDS_LOCATION/$1/hooks/pre-stop.sh"
+  if [ -x "$PRE_STOP_HOOK" ]; then
+    printf "Executing pre-stop hook script for world %s...\n" "$1"
+    "$PRE_STOP_HOOK"
+    if [ $? -ne 0 ]; then
+      printf "Warning: pre-stop hook script for world %s exited with a non-zero status.\n" "$1"
+    fi
+  fi
+
   # Stop the server monitor if it is running.
   stopServerMonitor $1
   # Tell the server to stop.

--- a/msctl
+++ b/msctl
@@ -1549,8 +1549,17 @@ start() {
   echo $PID >"$WORLDS_LOCATION/$1.pid"
   # Start the server crash monitor, if enabled.
   startServerMonitor $1
-}
 
+  # Hook script execution
+  HOOK_SCRIPT="$WORLD_DIR/hooks/post-start.sh"
+  if [ -x "$HOOK_SCRIPT" ]; then
+    printf "Executing post-start hook script for world %s...\n" "$1"
+    "$HOOK_SCRIPT"
+    if [ $? -ne 0 ]; then
+      printf "Warning: post-start hook script for world %s exited with a non-zero status.\n" "$1"
+    fi
+  fi
+}
 # ---------------------------------------------------------------------------
 # Stop the world server.
 #
@@ -1578,6 +1587,16 @@ stop() {
   fi
   # Remove the PID file for the world server.
   rm -f "$WORLDS_LOCATION/$1.pid"
+
+  # Hook script execution
+  HOOK_SCRIPT="$WORLDS_LOCATION/$1/hooks/post-stop.sh"
+  if [ -x "$HOOK_SCRIPT" ]; then
+    printf "Executing post-stop hook script for world %s...\n" "$1"
+    "$HOOK_SCRIPT"
+    if [ $? -ne 0 ]; then
+      printf "Warning: post-stop hook script for world %s exited with a non-zero status.\n" "$1"
+    fi
+  fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…ecuted, if they exists: hooks/post-start.sh - hooks/post-stop.sh

how did I get the idea? I asked ChatGPT if there is a way to have scripts automatically executed after a stop or start in MSCS, and it halucinated... as it didnt exist (yet), i added it :)